### PR TITLE
Mainly move facing-direction functions

### DIFF
--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/CameraControls.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/CameraControls.java
@@ -1,7 +1,6 @@
 package com.github.khanshoaib3.minecraft_access.features;
 
 import com.github.khanshoaib3.minecraft_access.MainClass;
-import com.github.khanshoaib3.minecraft_access.utils.ClientPlayerEntityUtils;
 import com.github.khanshoaib3.minecraft_access.utils.PlayerPositionUtils;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -212,10 +211,15 @@ public class CameraControls {
         minecraftClient.player.changeLookDirection(deltaX, deltaY);
 
         MainClass.infoLog("Rotating camera by x:%d y:%d".formatted((int) deltaX, (int) deltaY));
-        if (isRotatingHorizontal && ClientPlayerEntityUtils.getHorizontalFacingDirectionInWords(true) != null)
-            MainClass.speakWithNarrator(ClientPlayerEntityUtils.getHorizontalFacingDirectionInWords(true), true);
-        else if (!isRotatingHorizontal && ClientPlayerEntityUtils.getVerticalFacingDirectionInWords() != null)
-            MainClass.speakWithNarrator(ClientPlayerEntityUtils.getVerticalFacingDirectionInWords(), true);
+
+        PlayerPositionUtils pUtil = new PlayerPositionUtils(this.minecraftClient);
+        String horizontalDirection = pUtil.getHorizontalFacingDirectionInCardinal();
+        String verticalDirection = pUtil.getVerticalFacingDirectionInWords();
+
+        if (isRotatingHorizontal && horizontalDirection != null)
+            MainClass.speakWithNarrator(horizontalDirection, true);
+        else if (!isRotatingHorizontal && verticalDirection != null)
+            MainClass.speakWithNarrator(verticalDirection, true);
     }
 
     /**

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/ClientPlayerEntityUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/ClientPlayerEntityUtils.java
@@ -3,101 +3,12 @@ package com.github.khanshoaib3.minecraft_access.utils;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.resource.language.I18n;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Contains some functions related to the player entity
  */
 @Environment(EnvType.CLIENT)
 public class ClientPlayerEntityUtils {
-    /**
-     * Get the vertical direction of the player.
-     * @return the vertical direction. -999 on error.
-     */
-    public static int getVerticalFacingDirection() {
-        if (MinecraftClient.getInstance() == null) return -999;
-        if (MinecraftClient.getInstance().player == null) return -999;
-
-        return (int) MinecraftClient.getInstance().player.getRotationClient().x;
-    }
-
-    /**
-     * Get the vertical direction in words.
-     * @return the vertical direction in words. null on error.
-     */
-    public static @Nullable String getVerticalFacingDirectionInWords() {
-        if (MinecraftClient.getInstance() == null) return null;
-        if (MinecraftClient.getInstance().player == null) return null;
-
-        int angle = getVerticalFacingDirection();
-        if (angle == -999) return null;
-
-        String angleInWords = null;
-
-        if (angle >= -2 && angle <= 2) angleInWords = I18n.translate("minecraft_access.direction.vertical_angle_straight");
-        else if (angle <= -88 && angle >= -90) angleInWords = I18n.translate("minecraft_access.direction.vertical_angle_up");
-        else if (angle >= 88 && angle <= 90) angleInWords = I18n.translate("minecraft_access.direction.vertical_angle_down");
-
-        return angleInWords;
-    }
-
-    /**
-     * Get the horizontal direction of the player.
-     * @return the horizontal direction. -999 on error.
-     */
-    public static int getHorizontalFacingDirection() {
-        if (MinecraftClient.getInstance() == null) return -999;
-        if (MinecraftClient.getInstance().player == null) return -999;
-
-        int angle = (int) MinecraftClient.getInstance().player.getRotationClient().y;
-
-        while (angle >= 360) angle -= 360;
-        while (angle <= -360) angle += 360;
-
-        return angle;
-    }
-
-    // FIXME duplicate from new PlayerPositionUtils(minecraftClient).getHorizontalFacingDirectionInCardinal()
-    /**
-     * Get the horizontal direction in words.
-     * @param precise whether to only say the direction when in range or not
-     * @return the horizontal direction in words. null on error.
-     */
-    public static @Nullable String getHorizontalFacingDirectionInWords(boolean precise) {
-        if (MinecraftClient.getInstance() == null) return null;
-        if (MinecraftClient.getInstance().player == null) return null;
-
-        int angle = getHorizontalFacingDirection();
-        if (angle == -999) return null;
-
-        String angleInWords = MinecraftClient.getInstance().player.getHorizontalFacing().asString();
-
-        if ((angle >= -140 && angle <= -130) || (angle >= 220 && angle <= 230)) {
-            angleInWords = I18n.translate("minecraft_access.direction.horizontal_angle_north_east");
-        } else if ((angle >= -50 && angle <= -40) || (angle >= 310 && angle <= 320)) {
-            angleInWords = I18n.translate("minecraft_access.direction.horizontal_angle_south_east");
-        } else if ((angle >= 40 && angle <= 50) || (angle >= -320 && angle <= -310)) {
-            angleInWords = I18n.translate("minecraft_access.direction.horizontal_angle_south_west");
-        } else if ((angle >= 130 && angle <= 140) || (angle >= -230 && angle <= -220)) {
-            angleInWords = I18n.translate("minecraft_access.direction.horizontal_angle_north_west");
-        } else if (precise) {
-            if ((angle >= -185 && angle <= -175) || (angle >= 175 && angle <= 185)) {
-                angleInWords = I18n.translate("minecraft_access.direction.horizontal_angle_north");
-            } else if ((angle >= -95 && angle <= -85) || (angle >= 265 && angle <= 275)) {
-                angleInWords = I18n.translate("minecraft_access.direction.horizontal_angle_east");
-            } else if ((angle >= -5 && angle <= 5)) {
-                angleInWords = I18n.translate("minecraft_access.direction.horizontal_angle_south");
-            } else if ((angle >= 85 && angle <= 95) || (angle >= -275 && angle <= -265)) {
-                angleInWords = I18n.translate("minecraft_access.direction.horizontal_angle_west");
-            } else {
-                angleInWords = null;
-            }
-        }
-
-        return angleInWords;
-    }
-
     public static int getExperienceLevel() {
         if (MinecraftClient.getInstance() == null) return -999;
         if (MinecraftClient.getInstance().player == null) return -999;

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerPositionUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerPositionUtils.java
@@ -4,7 +4,11 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.Nullable;
 
+/**
+ * Functions about getting player entity's position, facing direction etc.
+ */
 public class PlayerPositionUtils {
     private final PlayerEntity player;
 
@@ -16,7 +20,7 @@ public class PlayerPositionUtils {
         assert player != null;
         Vec3d pos = player.getPos();
 
-        String tempPosX = pos.x + "";
+        String tempPosX = String.valueOf(pos.x);
         tempPosX = tempPosX.substring(0, tempPosX.indexOf(".") + 2);
 
         return Double.parseDouble(tempPosX);
@@ -27,7 +31,7 @@ public class PlayerPositionUtils {
         Vec3d pos = player.getPos();
 
         String tempPosY;
-        tempPosY = pos.y + "";
+        tempPosY = String.valueOf(pos.y);
         tempPosY = tempPosY.substring(0, tempPosY.indexOf(".") + 2);
 
         return Double.parseDouble(tempPosY);
@@ -38,7 +42,7 @@ public class PlayerPositionUtils {
         Vec3d pos = player.getPos();
 
         String tempPosZ;
-        tempPosZ = pos.z + "";
+        tempPosZ = String.valueOf(pos.z);
         tempPosZ = tempPosZ.substring(0, tempPosZ.indexOf(".") + 2);
 
         return Double.parseDouble(tempPosZ);
@@ -61,6 +65,30 @@ public class PlayerPositionUtils {
         return (int) player.getRotationClient().x;
     }
 
+    /**
+     * Get the vertical direction in words.
+     *
+     * @return the vertical direction in words. null on error.
+     */
+    public @Nullable String getVerticalFacingDirectionInWords() {
+        if (MinecraftClient.getInstance() == null) return null;
+        if (MinecraftClient.getInstance().player == null) return null;
+
+        int angle = getVerticalFacingDirection();
+        if (angle == -999) return null;
+
+        String angleInWords = null;
+
+        if (angle >= -2 && angle <= 2)
+            angleInWords = I18n.translate("minecraft_access.direction.vertical_angle_straight");
+        else if (angle <= -88 && angle >= -90)
+            angleInWords = I18n.translate("minecraft_access.direction.vertical_angle_up");
+        else if (angle >= 88 && angle <= 90)
+            angleInWords = I18n.translate("minecraft_access.direction.vertical_angle_down");
+
+        return angleInWords;
+    }
+
     public int getHorizontalFacingDirectionInDegrees() {
         assert player != null;
         int angle = (int) player.getRotationClient().y;
@@ -80,6 +108,13 @@ public class PlayerPositionUtils {
         return getHorizontalFacingDirectionInCardinal(onlyDirectionKey, false);
     }
 
+    /**
+     * Get the horizontal direction in words.
+     *
+     * @param onlyDirectionKey  directly return the direction word without i18n it.
+     * @param oppositeDirection output the opposite direction instead.
+     * @return onlyDirectionKey ? direction word : translated direction
+     */
     public String getHorizontalFacingDirectionInCardinal(boolean onlyDirectionKey, boolean oppositeDirection) {
         assert player != null;
 
@@ -102,7 +137,7 @@ public class PlayerPositionUtils {
             direction = player.getHorizontalFacing().asString().toLowerCase();
         }
 
-        if(oppositeDirection) direction = getOppositeDirectionKey(direction);
+        if (oppositeDirection) direction = getOppositeDirectionKey(direction);
 
         if (onlyDirectionKey) return direction;
         else return I18n.translate("minecraft_access.direction.horizontal_angle_" + direction);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PositionUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PositionUtils.java
@@ -6,7 +6,9 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 
-//TODO add doc
+/**
+ * Functions about getting blocks' position.
+ */
 public class PositionUtils {
     public static String getNarratableNumber(double d) {
         return d >= 0 ? String.valueOf(d) : I18n.translate("minecraft_access.other.negative", -d);


### PR DESCRIPTION
Resolve a [TODO](https://github.com/khanshoaib3/minecraft-access/blob/b6702826583a9580dd9b57da88a68fe1891f5990/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/ClientPlayerEntityUtils.java#L61) about duplicate function.
Mainly move facing-direction functions from `ClientPlayerEntityUtils` to `PlayerPositionUtils`.
BTW, it may be good to combine `PlayerPositionUtils` and `PositionUtils` together.