### PR TITLE
Reset previousQuery after every 5000ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ redstone signal or when a door is open and other similar cases.
 1. Enabled = Enables this feature.
 2. Speak Block Sides = Enables speaking of the side of block as well.
 3. Disable Speaking Consecutive Blocks With Same Name = Disables speaking the block if the previous block was also same.
+4. Repeat Speaking Interval (in milliseconds) = Repeat speaking the block you are facing for the given amount of time, even you haven't moved the camera.
+   Zero for tuning it off, default: 5000.
 
 ## Position Narrator
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/ConfigMap.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/ConfigMap.java
@@ -137,6 +137,7 @@ public class ConfigMap {
         defaultReadCrosshairConfigMap.setEnabled(true);
         defaultReadCrosshairConfigMap.setSpeakSide(true);
         defaultReadCrosshairConfigMap.setDisableSpeakingConsecutiveBlocks(true);
+        defaultReadCrosshairConfigMap.setRepeatSpeakingInterval(5000L);
 
         setReadCrosshairConfigMap(defaultReadCrosshairConfigMap);
     }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/feature_config_maps/ReadCrosshairConfigMap.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/feature_config_maps/ReadCrosshairConfigMap.java
@@ -9,6 +9,8 @@ public class ReadCrosshairConfigMap {
     private boolean speakSide;
     @SerializedName("Disable Speaking Consecutive Blocks With Same Name")
     private boolean disableSpeakingConsecutiveBlocks;
+    @SerializedName("Repeat Speaking Interval (in milliseconds)")
+    private long repeatSpeakingInterval;
 
     public boolean isEnabled() {
         return enabled;
@@ -32,5 +34,13 @@ public class ReadCrosshairConfigMap {
 
     public void setDisableSpeakingConsecutiveBlocks(boolean disableSpeakingConsecutiveBlocks) {
         this.disableSpeakingConsecutiveBlocks = disableSpeakingConsecutiveBlocks;
+    }
+
+    public long getRepeatSpeakingInterval() {
+        return repeatSpeakingInterval;
+    }
+
+    public void setRepeatSpeakingInterval(long repeatSpeakingInterval) {
+        this.repeatSpeakingInterval = repeatSpeakingInterval;
     }
 }


### PR DESCRIPTION
Solve a related [TODO](https://github.com/khanshoaib3/minecraft-access/blob/b6702826583a9580dd9b57da88a68fe1891f5990/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java#L54).

BTW, there are some `toSpeak` variables in `ReadCrosshair.class` that marked as *unused*, is that normal?