### PR TITLE
Chore Narration improvements

### DIFF
--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
@@ -105,8 +105,14 @@ public class ReadCrosshair {
         try {
             String currentQuery = hit.getEntity().getName().getString();
             if (hit.getEntity() instanceof AnimalEntity animalEntity) {
-                if (animalEntity instanceof SheepEntity sheepEntity)
-                    currentQuery = "%s %s".formatted(sheepEntity.getColor().getName(), currentQuery);
+                if (animalEntity instanceof SheepEntity sheepEntity) {
+                    String color = sheepEntity.getColor().getName();
+                    String translatedColor = I18n.translate("minecraft_access.color." + color);
+                    String shearable = sheepEntity.isShearable() ?
+                            I18n.translate("minecraft_access.other.shearable") :
+                            I18n.translate("minecraft_access.other.not_shearable");
+                    currentQuery = "%s %s %s".formatted(translatedColor, currentQuery, shearable);
+                }
                 if (animalEntity.isBaby())
                     currentQuery = I18n.translate("minecraft_access.read_crosshair.animal_entity_baby", currentQuery);
                 if (animalEntity.isLeashed())
@@ -150,7 +156,7 @@ public class ReadCrosshair {
             }
             side = I18n.translate(prefix + d.getName());
         }
-        toSpeak +=  " " + side;
+        toSpeak += " " + side;
 
         // Class name in production environment can be different
         String blockPos = hit.getBlockPos().toImmutable().toString();

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/narrator_menu/NarratorMenu.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/narrator_menu/NarratorMenu.java
@@ -210,7 +210,7 @@ public class NarratorMenu {
                 }
             }
 
-            String toSpeak = "%d:%d".formatted(hours, minutes);
+            String toSpeak = "%02d:%02d".formatted(hours, minutes);
             toSpeak = I18n.translate(translationKey, toSpeak);
             MainClass.speakWithNarrator(toSpeak, true);
         } catch (Exception e) {

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/InGameHudMixin.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/InGameHudMixin.java
@@ -28,7 +28,10 @@ public class InGameHudMixin {
     @Inject(at = @At("TAIL"), method = "renderHeldItemTooltip")
     public void renderHeldItemTooltipMixin(MatrixStack matrixStack, CallbackInfo callbackInfo) {
         if (this.heldItemTooltipFade == 38 && !this.currentStack.isEmpty()/*FIXME && Config.get(Config.getHelditemnarratorkey())*/) {
-            MutableText mutableText = net.minecraft.text.Text.empty().append(this.currentStack.getName()).formatted(this.currentStack.getRarity().formatting);
+            MutableText mutableText = net.minecraft.text.Text.empty()
+                    .append(String.valueOf(this.currentStack.getCount()))
+                    .append(this.currentStack.getName())
+                    .formatted(this.currentStack.getRarity().formatting);
             MainClass.speakWithNarrator(I18n.translate("minecraft_access.other.hotbar", mutableText.getString()), true);
         }
     }


### PR DESCRIPTION
Narration improvements:
1. Add zero pad in time speaking, not "1:7" but "01:07"
2. Add count speaking of currently held item.
3. Translate the sheep's color (when a sheep is targeted), also add shearable info, with https://github.com/khanshoaib3/minecraft-access-i18n/pull/4