### PR TITLE
Comparator info fix; Bug fix for redstone related blocks; Refactored i18n entries;

### DIFF
--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
@@ -4,7 +4,9 @@ import com.github.khanshoaib3.minecraft_access.MainClass;
 import com.github.khanshoaib3.minecraft_access.config.config_maps.ReadCrosshairConfigMap;
 import com.github.khanshoaib3.minecraft_access.utils.PlayerPositionUtils;
 import net.minecraft.block.*;
-import net.minecraft.block.entity.*;
+import net.minecraft.block.entity.BeehiveBlockEntity;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.SignBlockEntity;
 import net.minecraft.block.enums.ComparatorMode;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.resource.language.I18n;
@@ -270,14 +272,15 @@ public class ReadCrosshair {
                 currentQuery += "powered";
             }
         } else if (block instanceof ComparatorBlock) {
-            BlockEntity blockEntity = world.getBlockEntity(blockPos);
-            int outputPower = blockEntity instanceof ComparatorBlockEntity ? ((ComparatorBlockEntity) blockEntity).getOutputSignal() : 0;
             ComparatorMode mode = blockState.get(ComparatorBlock.MODE);
             Direction facing = blockState.get(ComparatorBlock.FACING);
             String correctFacing = I18n.translate("minecraft_access.direction.horizontal_angle_" + PlayerPositionUtils.getOppositeDirectionKey(facing.getName()).toLowerCase());
-
-            toSpeak = I18n.translate("minecraft_access.read_crosshair.comparator_info", toSpeak, correctFacing, mode, outputPower);
-            currentQuery += "mode:" + mode + " output_power:" + outputPower + " facing:" + correctFacing;
+            toSpeak = I18n.translate("minecraft_access.read_crosshair.comparator_info", toSpeak, correctFacing, mode);
+            if (isReceivingPower) {
+                toSpeak = I18n.translate("minecraft_access.read_crosshair.powered", toSpeak);
+                currentQuery += "powered";
+            }
+            currentQuery += "mode:" + mode + " facing:" + correctFacing;
         } else if (block instanceof RepeaterBlock) {
             boolean locked = blockState.get(RepeaterBlock.LOCKED);
             int delay = blockState.get(RepeaterBlock.DELAY);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
@@ -205,13 +205,9 @@ public class ReadCrosshair {
             }
 
             // Redstone related
-            boolean isEmittingPower = clientWorld.isEmittingRedstonePower(hit.getBlockPos(), Direction.DOWN);
-            boolean isReceivingPower = clientWorld.isReceivingRedstonePower(hit.getBlockPos());
-            if (isEmittingPower || isReceivingPower) {
-                Pair<String, String> redstoneRelatedInfo = getRedstoneRelatedInfo(clientWorld, blockPos, block, blockState, toSpeak, currentQuery);
-                toSpeak = redstoneRelatedInfo.getLeft();
-                currentQuery = redstoneRelatedInfo.getRight();
-            }
+            Pair<String, String> redstoneRelatedInfo = getRedstoneRelatedInfo(clientWorld, blockPos, block, blockState, toSpeak, currentQuery);
+            toSpeak = redstoneRelatedInfo.getLeft();
+            currentQuery = redstoneRelatedInfo.getRight();
 
         } catch (Exception e) {
             MainClass.errorLog("An error occurred while adding narration text for special blocks");

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
@@ -161,13 +161,7 @@ public class ReadCrosshair {
         String side = "";
         if (this.speakSide) {
             Direction d = hit.getSide();
-            String prefix;
-            if (Direction.UP.equals(d) || Direction.DOWN.equals(d)) {
-                prefix = "minecraft_access.direction.vertical_angle_";
-            } else {
-                prefix = "minecraft_access.direction.horizontal_angle_";
-            }
-            side = I18n.translate(prefix + d.getName());
+            side = I18n.translate("minecraft_access.direction." + d.getName());
         }
         toSpeak += " " + side;
 
@@ -251,21 +245,21 @@ public class ReadCrosshair {
             toSpeak = I18n.translate("minecraft_access.read_crosshair.opened", toSpeak);
             currentQuery += "open";
         } else if (block instanceof HopperBlock) {
-            toSpeak = I18n.translate("minecraft_access.read_crosshair.facing", toSpeak, I18n.translate("minecraft_access.direction.horizontal_angle_" + blockState.get(HopperBlock.FACING).getName()));
+            toSpeak = I18n.translate("minecraft_access.read_crosshair.facing", toSpeak, I18n.translate("minecraft_access.direction." + blockState.get(HopperBlock.FACING).getName()));
             currentQuery += "facing " + blockState.get(HopperBlock.FACING).getName();
             if (isReceivingPower) {
                 toSpeak = I18n.translate("minecraft_access.read_crosshair.locked", toSpeak);
                 currentQuery += "locked";
             }
         } else if (block instanceof ObserverBlock) {
-            toSpeak = I18n.translate("minecraft_access.read_crosshair.facing", toSpeak, I18n.translate("minecraft_access.direction.horizontal_angle_" + blockState.get(ObserverBlock.FACING).getName()));
+            toSpeak = I18n.translate("minecraft_access.read_crosshair.facing", toSpeak, I18n.translate("minecraft_access.direction." + blockState.get(ObserverBlock.FACING).getName()));
             currentQuery += "facing " + blockState.get(ObserverBlock.FACING).getName();
             if (isEmittingPower) {
                 toSpeak = I18n.translate("minecraft_access.read_crosshair.powered", toSpeak);
                 currentQuery += "powered";
             }
         } else if (block instanceof DispenserBlock) {
-            toSpeak = I18n.translate("minecraft_access.read_crosshair.facing", toSpeak, I18n.translate("minecraft_access.direction.horizontal_angle_" + blockState.get(DispenserBlock.FACING).getName()));
+            toSpeak = I18n.translate("minecraft_access.read_crosshair.facing", toSpeak, I18n.translate("minecraft_access.direction." + blockState.get(DispenserBlock.FACING).getName()));
             currentQuery += "facing " + blockState.get(DispenserBlock.FACING).getName();
             if (isReceivingPower) {
                 toSpeak = I18n.translate("minecraft_access.read_crosshair.powered", toSpeak);
@@ -274,7 +268,7 @@ public class ReadCrosshair {
         } else if (block instanceof ComparatorBlock) {
             ComparatorMode mode = blockState.get(ComparatorBlock.MODE);
             Direction facing = blockState.get(ComparatorBlock.FACING);
-            String correctFacing = I18n.translate("minecraft_access.direction.horizontal_angle_" + PlayerPositionUtils.getOppositeDirectionKey(facing.getName()).toLowerCase());
+            String correctFacing = I18n.translate("minecraft_access.direction." + PlayerPositionUtils.getOppositeDirectionKey(facing.getName()).toLowerCase());
             toSpeak = I18n.translate("minecraft_access.read_crosshair.comparator_info", toSpeak, correctFacing, mode);
             if (isReceivingPower) {
                 toSpeak = I18n.translate("minecraft_access.read_crosshair.powered", toSpeak);
@@ -285,7 +279,7 @@ public class ReadCrosshair {
             boolean locked = blockState.get(RepeaterBlock.LOCKED);
             int delay = blockState.get(RepeaterBlock.DELAY);
             Direction facing = blockState.get(ComparatorBlock.FACING);
-            String correctFacing = I18n.translate("minecraft_access.direction.horizontal_angle_" + PlayerPositionUtils.getOppositeDirectionKey(facing.getName()).toLowerCase());
+            String correctFacing = I18n.translate("minecraft_access.direction." + PlayerPositionUtils.getOppositeDirectionKey(facing.getName()).toLowerCase());
 
             toSpeak = I18n.translate("minecraft_access.read_crosshair.repeater_info", toSpeak, correctFacing, delay);
             currentQuery += "delay:" + delay + " facing:" + correctFacing;

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerPositionUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerPositionUtils.java
@@ -80,11 +80,11 @@ public class PlayerPositionUtils {
         String angleInWords = null;
 
         if (angle >= -2 && angle <= 2)
-            angleInWords = I18n.translate("minecraft_access.direction.vertical_angle_straight");
+            angleInWords = I18n.translate("minecraft_access.direction.straight");
         else if (angle <= -88 && angle >= -90)
-            angleInWords = I18n.translate("minecraft_access.direction.vertical_angle_up");
+            angleInWords = I18n.translate("minecraft_access.direction.up");
         else if (angle >= 88 && angle <= 90)
-            angleInWords = I18n.translate("minecraft_access.direction.vertical_angle_down");
+            angleInWords = I18n.translate("minecraft_access.direction.down");
 
         return angleInWords;
     }
@@ -140,7 +140,7 @@ public class PlayerPositionUtils {
         if (oppositeDirection) direction = getOppositeDirectionKey(direction);
 
         if (onlyDirectionKey) return direction;
-        else return I18n.translate("minecraft_access.direction.horizontal_angle_" + direction);
+        else return I18n.translate("minecraft_access.direction." + direction);
     }
 
     public static String getOppositeDirectionKey(String originalDirectionKey) {


### PR DESCRIPTION
- Removed comparator output power info as it is not working
- Added powered prefix to comparator info
- Fixed a bug in which the redstone related blocks info were only being said when the block was receiving or emitting power
- Refactored direction entries to fix bugs