### PR TITLE
Partial speaking crosshair

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ redstone signal or when a door is open and other similar cases.
 3. Disable Speaking Consecutive Blocks With Same Name = Disables speaking the block if the previous block was also same.
 4. Repeat Speaking Interval (in milliseconds) = Repeat speaking the block you are facing for the given amount of time, even you haven't moved the camera.
    Zero for tuning it off, default: 5000.
+5. Enable Partial Speaking = Let the mod only speak entities/blocks that you've configured.
+6. Partial Speaking White List Mode = If true, only speak what you've configured, if false for blacklist mode, only not spak what you've configured.
+7. Partial Speaking Fuzzy Mode = Whether to do fuzzy matching, for example "bed" will match all colors of beds, "door" will match all textures of doors.
+8. Partial Speaking Target Mode = Which type would you like to apply this feature to, either "all", "entity" or "block".
+This configuration can only be configured in config.json file.
+9. Partial Speaking Targets = Indicated what to be spoken.
+This configuration can only be configured in config.json file.
+Values are written in Minecraft resource location format,
+the so-called "snake_case", and consists of lowercase letters with underscores.
+For example, the White Bed is written in "white_bed" and pronounced as "white underscore bed".
+There are lots of exceptions, the "Smooth Quartz Block" is written in "smooth_quartz", the "Block of Diamond" is written in "diamond_block", 
+so please check the correct values in this wiki link:
+https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
 
 ## Position Narrator
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/ConfigMap.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/ConfigMap.java
@@ -30,7 +30,7 @@ public class ConfigMap {
         m.poiConfigMap = POIConfigMap.buildDefault();
         m.setDefaultPlayerWarningConfigMap();
         m.setFallDetectorConfigMap(FallDetectorConfigMap.defaultFallDetectorConfigMap());
-        m.setDefaultReadCrosshairConfigMap();
+        m.readCrosshairConfigMap = ReadCrosshairConfigMap.buildDefault();
         m.setOtherConfigsMap(OtherConfigsMap.getDefaultOtherConfigsMap());
         m.setNarratorMenuConfigMap(NarratorMenuConfigMap.getDefaultNarratorMenuConfigMap());
         return m;
@@ -38,6 +38,7 @@ public class ConfigMap {
 
     public static void setInstance(ConfigMap map) {
         POIConfigMap.setInstance(map.poiConfigMap);
+        ReadCrosshairConfigMap.setInstance(map.readCrosshairConfigMap);
     }
 
     public CameraControlsConfigMap getCameraControlsConfigMap() {
@@ -110,20 +111,6 @@ public class ConfigMap {
 
     public ReadCrosshairConfigMap getReadCrosshairConfigMap() {
         return readCrosshairConfigMap;
-    }
-
-    public void setReadCrosshairConfigMap(ReadCrosshairConfigMap readCrosshairConfigMap) {
-        this.readCrosshairConfigMap = readCrosshairConfigMap;
-    }
-
-    public void setDefaultReadCrosshairConfigMap() {
-        ReadCrosshairConfigMap defaultReadCrosshairConfigMap = new ReadCrosshairConfigMap();
-        defaultReadCrosshairConfigMap.setEnabled(true);
-        defaultReadCrosshairConfigMap.setSpeakSide(true);
-        defaultReadCrosshairConfigMap.setDisableSpeakingConsecutiveBlocks(true);
-        defaultReadCrosshairConfigMap.setRepeatSpeakingInterval(0L);
-
-        setReadCrosshairConfigMap(defaultReadCrosshairConfigMap);
     }
 
     public OtherConfigsMap getOtherConfigsMap() {

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/RCPartialSpeakingConfigMap.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/RCPartialSpeakingConfigMap.java
@@ -1,0 +1,92 @@
+package com.github.khanshoaib3.minecraft_access.config.config_maps;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class RCPartialSpeakingConfigMap {
+    private static RCPartialSpeakingConfigMap instance;
+
+    @SerializedName("Enabled")
+    private boolean enabled;
+    @SerializedName("White List Mode")
+    private boolean partialSpeakingWhitelistMode;
+    @SerializedName("Fuzzy Matching Mode")
+    private boolean partialSpeakingFuzzyMode;
+    @SerializedName("Target Mode")
+    private PartialSpeakingTargetMode partialSpeakingTargetMode;
+    @SerializedName("Targets")
+    private List<String> partialSpeakingTargets;
+
+    public static RCPartialSpeakingConfigMap buildDefault() {
+        RCPartialSpeakingConfigMap m = new RCPartialSpeakingConfigMap();
+        m.enabled = true;
+        m.partialSpeakingWhitelistMode = true;
+        m.partialSpeakingFuzzyMode = true;
+        m.partialSpeakingTargets = List.of("slab", "planks", "block", "stone", "sign");
+        m.partialSpeakingTargetMode = PartialSpeakingTargetMode.BLOCK;
+
+        setInstance(m);
+        return m;
+    }
+
+    public static void setInstance(RCPartialSpeakingConfigMap map) {
+        instance = map;
+    }
+
+    public static RCPartialSpeakingConfigMap getInstance() {
+        return instance;
+    }
+
+    public enum PartialSpeakingTargetMode {
+        @SerializedName("all")
+        ALL,
+        @SerializedName("entity")
+        ENTITY,
+        @SerializedName("block")
+        BLOCK,
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public RCPartialSpeakingConfigMap setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public boolean isPartialSpeakingWhitelistMode() {
+        return partialSpeakingWhitelistMode;
+    }
+
+    public void setPartialSpeakingWhitelistMode(boolean partialSpeakingWhitelistMode) {
+        this.partialSpeakingWhitelistMode = partialSpeakingWhitelistMode;
+    }
+
+    public List<String> getPartialSpeakingTargets() {
+        return partialSpeakingTargets;
+    }
+
+    @SuppressWarnings("unused")
+    public void setPartialSpeakingTargets(List<String> partialSpeakingBlocks) {
+        this.partialSpeakingTargets = partialSpeakingBlocks;
+    }
+
+    public boolean isPartialSpeakingFuzzyMode() {
+        return partialSpeakingFuzzyMode;
+    }
+
+    public void setPartialSpeakingFuzzyMode(boolean partialSpeakingFuzzyMode) {
+        this.partialSpeakingFuzzyMode = partialSpeakingFuzzyMode;
+    }
+
+    public PartialSpeakingTargetMode getPartialSpeakingTargetMode() {
+        return partialSpeakingTargetMode;
+    }
+
+    @SuppressWarnings("unused")
+    public void setPartialSpeakingTargetMode(PartialSpeakingTargetMode partialSpeakingTargetMode) {
+        this.partialSpeakingTargetMode = partialSpeakingTargetMode;
+    }
+}

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/ReadCrosshairConfigMap.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/ReadCrosshairConfigMap.java
@@ -33,7 +33,7 @@ public class ReadCrosshairConfigMap {
         m.setEnablePartialSpeaking(false);
         m.setPartialSpeakingWhitelistMode(true);
         m.setPartialSpeakingFuzzyMode(true);
-        m.setPartialSpeakingTargets(List.of("slab", "white_bed", "planks"));
+        m.setPartialSpeakingTargets(List.of("slab", "white_bed", "planks", "block"));
         return m;
     }
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/ReadCrosshairConfigMap.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/ReadCrosshairConfigMap.java
@@ -2,8 +2,6 @@ package com.github.khanshoaib3.minecraft_access.config.config_maps;
 
 import com.google.gson.annotations.SerializedName;
 
-import java.util.List;
-
 public class ReadCrosshairConfigMap {
     private static ReadCrosshairConfigMap instance;
 
@@ -15,25 +13,9 @@ public class ReadCrosshairConfigMap {
     private boolean disableSpeakingConsecutiveBlocks;
     @SerializedName("Repeat Speaking Interval (in milliseconds) (0 to disable)")
     private long repeatSpeakingInterval;
-    @SerializedName("Enable Partial Speaking")
-    private boolean enablePartialSpeaking;
-    @SerializedName("Partial Speaking White List Mode")
-    private boolean partialSpeakingWhitelistMode;
-    @SerializedName("Partial Speaking Fuzzy Mode")
-    private boolean partialSpeakingFuzzyMode;
-    @SerializedName("Partial Speaking Target Mode")
-    private PartialSpeakingTargetMode partialSpeakingTargetMode;
-    @SerializedName("Partial Speaking Targets")
-    private List<String> partialSpeakingTargets;
 
-    public enum PartialSpeakingTargetMode {
-        @SerializedName("all")
-        ALL,
-        @SerializedName("entity")
-        ENTITY,
-        @SerializedName("block")
-        BLOCK
-    }
+    @SerializedName("Partial Speaking")
+    private RCPartialSpeakingConfigMap partialSpeakingConfigMap;
 
     public static ReadCrosshairConfigMap buildDefault() {
         ReadCrosshairConfigMap m = new ReadCrosshairConfigMap();
@@ -41,11 +23,7 @@ public class ReadCrosshairConfigMap {
         m.setSpeakSide(true);
         m.setDisableSpeakingConsecutiveBlocks(true);
         m.setRepeatSpeakingInterval(0L);
-        m.setEnablePartialSpeaking(false);
-        m.setPartialSpeakingWhitelistMode(true);
-        m.setPartialSpeakingFuzzyMode(true);
-        m.setPartialSpeakingTargets(List.of("slab", "planks", "block", "stone", "sign"));
-        m.setPartialSpeakingTargetMode(PartialSpeakingTargetMode.BLOCK);
+        m.setPartialSpeakingConfigMap(RCPartialSpeakingConfigMap.buildDefault());
         return m;
     }
 
@@ -55,6 +33,7 @@ public class ReadCrosshairConfigMap {
 
     public static void setInstance(ReadCrosshairConfigMap map) {
         instance = map;
+        RCPartialSpeakingConfigMap.setInstance(map.partialSpeakingConfigMap);
     }
 
     public boolean isEnabled() {
@@ -89,43 +68,11 @@ public class ReadCrosshairConfigMap {
         this.repeatSpeakingInterval = repeatSpeakingInterval;
     }
 
-    public boolean isEnablePartialSpeaking() {
-        return enablePartialSpeaking;
+    public RCPartialSpeakingConfigMap getPartialSpeakingConfigMap() {
+        return partialSpeakingConfigMap;
     }
 
-    public void setEnablePartialSpeaking(boolean enablePartialSpeaking) {
-        this.enablePartialSpeaking = enablePartialSpeaking;
-    }
-
-    public boolean isPartialSpeakingWhitelistMode() {
-        return partialSpeakingWhitelistMode;
-    }
-
-    public void setPartialSpeakingWhitelistMode(boolean partialSpeakingWhitelistMode) {
-        this.partialSpeakingWhitelistMode = partialSpeakingWhitelistMode;
-    }
-
-    public List<String> getPartialSpeakingTargets() {
-        return partialSpeakingTargets;
-    }
-
-    public void setPartialSpeakingTargets(List<String> partialSpeakingBlocks) {
-        this.partialSpeakingTargets = partialSpeakingBlocks;
-    }
-
-    public boolean isPartialSpeakingFuzzyMode() {
-        return partialSpeakingFuzzyMode;
-    }
-
-    public void setPartialSpeakingFuzzyMode(boolean partialSpeakingFuzzyMode) {
-        this.partialSpeakingFuzzyMode = partialSpeakingFuzzyMode;
-    }
-
-    public PartialSpeakingTargetMode getPartialSpeakingTargetMode() {
-        return partialSpeakingTargetMode;
-    }
-
-    public void setPartialSpeakingTargetMode(PartialSpeakingTargetMode partialSpeakingTargetMode) {
-        this.partialSpeakingTargetMode = partialSpeakingTargetMode;
+    public void setPartialSpeakingConfigMap(RCPartialSpeakingConfigMap partialSpeakingConfigMap) {
+        this.partialSpeakingConfigMap = partialSpeakingConfigMap;
     }
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/ReadCrosshairConfigMap.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/ReadCrosshairConfigMap.java
@@ -21,8 +21,19 @@ public class ReadCrosshairConfigMap {
     private boolean partialSpeakingWhitelistMode;
     @SerializedName("Partial Speaking Fuzzy Mode")
     private boolean partialSpeakingFuzzyMode;
+    @SerializedName("Partial Speaking Target Mode")
+    private PartialSpeakingTargetMode partialSpeakingTargetMode;
     @SerializedName("Partial Speaking Targets")
     private List<String> partialSpeakingTargets;
+
+    public enum PartialSpeakingTargetMode {
+        @SerializedName("all")
+        ALL,
+        @SerializedName("entity")
+        ENTITY,
+        @SerializedName("block")
+        BLOCK
+    }
 
     public static ReadCrosshairConfigMap buildDefault() {
         ReadCrosshairConfigMap m = new ReadCrosshairConfigMap();
@@ -33,7 +44,8 @@ public class ReadCrosshairConfigMap {
         m.setEnablePartialSpeaking(false);
         m.setPartialSpeakingWhitelistMode(true);
         m.setPartialSpeakingFuzzyMode(true);
-        m.setPartialSpeakingTargets(List.of("slab", "white_bed", "planks", "block"));
+        m.setPartialSpeakingTargets(List.of("slab", "planks", "block", "stone", "sign"));
+        m.setPartialSpeakingTargetMode(PartialSpeakingTargetMode.BLOCK);
         return m;
     }
 
@@ -107,5 +119,13 @@ public class ReadCrosshairConfigMap {
 
     public void setPartialSpeakingFuzzyMode(boolean partialSpeakingFuzzyMode) {
         this.partialSpeakingFuzzyMode = partialSpeakingFuzzyMode;
+    }
+
+    public PartialSpeakingTargetMode getPartialSpeakingTargetMode() {
+        return partialSpeakingTargetMode;
+    }
+
+    public void setPartialSpeakingTargetMode(PartialSpeakingTargetMode partialSpeakingTargetMode) {
+        this.partialSpeakingTargetMode = partialSpeakingTargetMode;
     }
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/ReadCrosshairConfigMap.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/ReadCrosshairConfigMap.java
@@ -2,7 +2,11 @@ package com.github.khanshoaib3.minecraft_access.config.config_maps;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.List;
+
 public class ReadCrosshairConfigMap {
+    private static ReadCrosshairConfigMap instance;
+
     @SerializedName("Enabled")
     private boolean enabled;
     @SerializedName("Speak Block Sides")
@@ -11,6 +15,35 @@ public class ReadCrosshairConfigMap {
     private boolean disableSpeakingConsecutiveBlocks;
     @SerializedName("Repeat Speaking Interval (in milliseconds) (0 to disable)")
     private long repeatSpeakingInterval;
+    @SerializedName("Enable Partial Speaking")
+    private boolean enablePartialSpeaking;
+    @SerializedName("Partial Speaking White List Mode")
+    private boolean partialSpeakingWhitelistMode;
+    @SerializedName("Partial Speaking Fuzzy Mode")
+    private boolean partialSpeakingFuzzyMode;
+    @SerializedName("Partial Speaking Targets")
+    private List<String> partialSpeakingTargets;
+
+    public static ReadCrosshairConfigMap buildDefault() {
+        ReadCrosshairConfigMap m = new ReadCrosshairConfigMap();
+        m.setEnabled(true);
+        m.setSpeakSide(true);
+        m.setDisableSpeakingConsecutiveBlocks(true);
+        m.setRepeatSpeakingInterval(0L);
+        m.setEnablePartialSpeaking(false);
+        m.setPartialSpeakingWhitelistMode(true);
+        m.setPartialSpeakingFuzzyMode(true);
+        m.setPartialSpeakingTargets(List.of("slab", "white_bed", "planks"));
+        return m;
+    }
+
+    public static ReadCrosshairConfigMap getInstance() {
+        return instance;
+    }
+
+    public static void setInstance(ReadCrosshairConfigMap map) {
+        instance = map;
+    }
 
     public boolean isEnabled() {
         return enabled;
@@ -42,5 +75,37 @@ public class ReadCrosshairConfigMap {
 
     public void setRepeatSpeakingInterval(long repeatSpeakingInterval) {
         this.repeatSpeakingInterval = repeatSpeakingInterval;
+    }
+
+    public boolean isEnablePartialSpeaking() {
+        return enablePartialSpeaking;
+    }
+
+    public void setEnablePartialSpeaking(boolean enablePartialSpeaking) {
+        this.enablePartialSpeaking = enablePartialSpeaking;
+    }
+
+    public boolean isPartialSpeakingWhitelistMode() {
+        return partialSpeakingWhitelistMode;
+    }
+
+    public void setPartialSpeakingWhitelistMode(boolean partialSpeakingWhitelistMode) {
+        this.partialSpeakingWhitelistMode = partialSpeakingWhitelistMode;
+    }
+
+    public List<String> getPartialSpeakingTargets() {
+        return partialSpeakingTargets;
+    }
+
+    public void setPartialSpeakingTargets(List<String> partialSpeakingBlocks) {
+        this.partialSpeakingTargets = partialSpeakingBlocks;
+    }
+
+    public boolean isPartialSpeakingFuzzyMode() {
+        return partialSpeakingFuzzyMode;
+    }
+
+    public void setPartialSpeakingFuzzyMode(boolean partialSpeakingFuzzyMode) {
+        this.partialSpeakingFuzzyMode = partialSpeakingFuzzyMode;
     }
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_menus/POIConfigMenu.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_menus/POIConfigMenu.java
@@ -9,6 +9,8 @@ import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.text.Text;
 
+import java.util.function.Function;
+
 @SuppressWarnings("DataFlowIssue")
 public class POIConfigMenu extends BaseScreen {
     public POIConfigMenu(String title, BaseScreen previousScreen) {
@@ -258,20 +260,20 @@ class POIMarkingConfigMenu extends BaseScreen {
 
         POIMarkingConfigMap map = POIMarkingConfigMap.getInstance();
 
-        ButtonWidget b1 = this.buildButtonWidget(translateFeatureToggleButtonMessage(map.isEnabled()),
+        ButtonWidget b1 = this.buildButtonWidget(featureToggleButtonMessage(map.isEnabled()),
                 (button) -> {
                     map.setEnabled(!map.isEnabled());
-                    button.setMessage(Text.of(translateFeatureToggleButtonMessage(map.isEnabled())));
+                    button.setMessage(Text.of(featureToggleButtonMessage(map.isEnabled())));
                     Config.getInstance().writeJSON();
                 });
         this.addDrawableChild(b1);
 
-        var m2 = buildFeatureToggleButtonMessageTranslator("minecraft_access.gui.poi_marking_config_menu.button.suppress_other_when_enabled_button");
+        Function<Boolean, String> t2 = featureToggleButtonMessageWith("minecraft_access.gui.poi_marking_config_menu.button.suppress_other_when_enabled_button");
         ButtonWidget b2 = this.buildButtonWidget(
-                m2.apply(map.isSuppressOtherWhenEnabled()),
+                t2.apply(map.isSuppressOtherWhenEnabled()),
                 (button) -> {
                     map.setSuppressOtherWhenEnabled(!map.isSuppressOtherWhenEnabled());
-                    button.setMessage(Text.of(m2.apply(map.isSuppressOtherWhenEnabled())));
+                    button.setMessage(Text.of(t2.apply(map.isSuppressOtherWhenEnabled())));
                     Config.getInstance().writeJSON();
                 });
         this.addDrawableChild(b2);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_menus/ReadCrosshairConfigMenu.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_menus/ReadCrosshairConfigMenu.java
@@ -1,11 +1,12 @@
 package com.github.khanshoaib3.minecraft_access.config.config_menus;
 
-import com.github.khanshoaib3.minecraft_access.MainClass;
-import com.github.khanshoaib3.minecraft_access.config.ConfigMap;
+import com.github.khanshoaib3.minecraft_access.config.Config;
+import com.github.khanshoaib3.minecraft_access.config.config_maps.ReadCrosshairConfigMap;
 import com.github.khanshoaib3.minecraft_access.utils.BaseScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.resource.language.I18n;
 import net.minecraft.text.Text;
+
+import java.util.function.Function;
 
 @SuppressWarnings("DataFlowIssue")
 public class ReadCrosshairConfigMenu extends BaseScreen {
@@ -17,51 +18,72 @@ public class ReadCrosshairConfigMenu extends BaseScreen {
     protected void init() {
         super.init();
 
-        ButtonWidget featureToggleButton = this.buildButtonWidget("minecraft_access.gui.common.button.feature_toggle_button." + (MainClass.config.getConfigMap().getReadCrosshairConfigMap().isEnabled() ? "enabled" : "disabled"),
+        ReadCrosshairConfigMap map = ReadCrosshairConfigMap.getInstance();
+
+        ButtonWidget featureToggleButton = this.buildButtonWidget(featureToggleButtonMessage(map.isEnabled()),
                 (button) -> {
-                    ConfigMap configMap = MainClass.config.getConfigMap();
-                    configMap.getReadCrosshairConfigMap().setEnabled(!configMap.getReadCrosshairConfigMap().isEnabled());
-                    MainClass.config.setConfigMap(configMap);
-                    button.setMessage(Text.of(I18n.translate("minecraft_access.gui.common.button.feature_toggle_button." + (MainClass.config.getConfigMap().getReadCrosshairConfigMap().isEnabled() ? "enabled" : "disabled"))));
+                    map.setEnabled(!map.isEnabled());
+                    button.setMessage(Text.of(featureToggleButtonMessage(map.isEnabled())));
+                    Config.getInstance().writeJSON();
                 });
         this.addDrawableChild(featureToggleButton);
 
+        Function<Boolean, String> speakBlockSidesText = featureToggleButtonMessageWith("minecraft_access.gui.read_crosshair_config_menu.button.speak_block_sides_button");
         ButtonWidget speakBlockSidesButton = this.buildButtonWidget(
-                I18n.translate("minecraft_access.gui.common.button.toggle_button." + (MainClass.config.getConfigMap().getReadCrosshairConfigMap().isSpeakSide() ? "enabled" : "disabled"),
-                        I18n.translate("minecraft_access.gui.read_crosshair_config_menu.button.speak_block_sides_button")
-                ),
+                speakBlockSidesText.apply(map.isSpeakSide()),
                 (button) -> {
-                    ConfigMap configMap = MainClass.config.getConfigMap();
-                    configMap.getReadCrosshairConfigMap().setSpeakSide(!configMap.getReadCrosshairConfigMap().isSpeakSide());
-                    MainClass.config.setConfigMap(configMap);
-                    button.setMessage(Text.of(I18n.translate("minecraft_access.gui.common.button.toggle_button." + (MainClass.config.getConfigMap().getReadCrosshairConfigMap().isSpeakSide() ? "enabled" : "disabled"),
-                            I18n.translate("minecraft_access.gui.read_crosshair_config_menu.button.speak_block_sides_button")
-                    )));
+                    map.setSpeakSide(!map.isSpeakSide());
+                    button.setMessage(Text.of(speakBlockSidesText.apply(map.isSpeakSide())));
+                    Config.getInstance().writeJSON();
                 });
         this.addDrawableChild(speakBlockSidesButton);
 
+        Function<Boolean, String> disableConsecutiveBlocksText = featureToggleButtonMessageWith("minecraft_access.gui.read_crosshair_config_menu.button.disable_speaking_consecutive_blocks_button");
         ButtonWidget disableConsecutiveBlocksButton = this.buildButtonWidget(
-                I18n.translate("minecraft_access.gui.common.button.toggle_button." + (MainClass.config.getConfigMap().getReadCrosshairConfigMap().isSpeakSide() ? "enabled" : "disabled"),
-                        I18n.translate("minecraft_access.gui.read_crosshair_config_menu.button.disable_speaking_consecutive_blocks_button")
-                ),
+                disableConsecutiveBlocksText.apply(map.isDisableSpeakingConsecutiveBlocks()),
                 (button) -> {
-                    ConfigMap configMap = MainClass.config.getConfigMap();
-                    configMap.getReadCrosshairConfigMap().setSpeakSide(!configMap.getReadCrosshairConfigMap().isSpeakSide());
-                    MainClass.config.setConfigMap(configMap);
-                    button.setMessage(Text.of(I18n.translate("minecraft_access.gui.common.button.toggle_button." + (MainClass.config.getConfigMap().getReadCrosshairConfigMap().isSpeakSide() ? "enabled" : "disabled"),
-                            I18n.translate("minecraft_access.gui.read_crosshair_config_menu.button.disable_speaking_consecutive_blocks_button")
-                    )));
+                    map.setDisableSpeakingConsecutiveBlocks(!map.isDisableSpeakingConsecutiveBlocks());
+                    button.setMessage(Text.of(disableConsecutiveBlocksText.apply(map.isDisableSpeakingConsecutiveBlocks())));
+                    Config.getInstance().writeJSON();
                 },
                 true);
         this.addDrawableChild(disableConsecutiveBlocksButton);
 
         ButtonWidget repeatSpeakingIntervalButton = this.buildButtonWidget(
-                I18n.translate("minecraft_access.gui.common.button.button_with_float_value",
-                        I18n.translate("minecraft_access.gui.read_crosshair_config_menu.button.repeat_speaking_interval_button"),
-                        MainClass.config.getConfigMap().getReadCrosshairConfigMap().getRepeatSpeakingInterval()
-                ),
+                floatValueButtonMessageWith("minecraft_access.gui.read_crosshair_config_menu.button.repeat_speaking_interval_button",
+                        map.getRepeatSpeakingInterval()),
                 (button) -> this.client.setScreen(new ValueEntryMenu("value_entry_menu", ValueEntryMenu.CONFIG_TYPE.READ_CROSSHAIR_REPEAT_SPEAKING_INTERVAL, this)),
                 true);
         this.addDrawableChild(repeatSpeakingIntervalButton);
+
+        Function<Boolean, String> enablePartialSpeakingText = featureToggleButtonMessageWith("minecraft_access.gui.read_crosshair_config_menu.button.partial_speaking_button");
+        ButtonWidget enablePartialSpeakingButton = this.buildButtonWidget(
+                  enablePartialSpeakingText.apply(map.isEnablePartialSpeaking()),
+                (button) -> {
+                    map.setEnablePartialSpeaking(!map.isEnablePartialSpeaking());
+                    button.setMessage(Text.of(enablePartialSpeakingText.apply(map.isEnablePartialSpeaking())));
+                    Config.getInstance().writeJSON();
+                });
+        this.addDrawableChild(enablePartialSpeakingButton);
+
+        Function<Boolean, String> partialSpeakingWhitelistModeText = featureToggleButtonMessageWith("minecraft_access.gui.read_crosshair_config_menu.button.partial_speaking_whitelist_mode_button");
+        ButtonWidget partialSpeakingWhitelistModeButton = this.buildButtonWidget(
+                  partialSpeakingWhitelistModeText.apply(map.isPartialSpeakingWhitelistMode()),
+                (button) -> {
+                    map.setPartialSpeakingWhitelistMode(!map.isPartialSpeakingWhitelistMode());
+                    button.setMessage(Text.of(partialSpeakingWhitelistModeText.apply(map.isPartialSpeakingWhitelistMode())));
+                    Config.getInstance().writeJSON();
+                });
+        this.addDrawableChild(partialSpeakingWhitelistModeButton);
+
+        Function<Boolean, String> partialSpeakingFuzzyModeText = featureToggleButtonMessageWith("minecraft_access.gui.read_crosshair_config_menu.button.partial_speaking_fuzzy_mode_button");
+        ButtonWidget partialSpeakingFuzzyModeButton = this.buildButtonWidget(
+                  partialSpeakingFuzzyModeText.apply(map.isPartialSpeakingFuzzyMode()),
+                (button) -> {
+                    map.setPartialSpeakingFuzzyMode(!map.isPartialSpeakingFuzzyMode());
+                    button.setMessage(Text.of(partialSpeakingFuzzyModeText.apply(map.isPartialSpeakingFuzzyMode())));
+                    Config.getInstance().writeJSON();
+                });
+        this.addDrawableChild(partialSpeakingFuzzyModeButton);
     }
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_menus/ReadCrosshairConfigMenu.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_menus/ReadCrosshairConfigMenu.java
@@ -1,6 +1,7 @@
 package com.github.khanshoaib3.minecraft_access.config.config_menus;
 
 import com.github.khanshoaib3.minecraft_access.config.Config;
+import com.github.khanshoaib3.minecraft_access.config.config_maps.RCPartialSpeakingConfigMap;
 import com.github.khanshoaib3.minecraft_access.config.config_maps.ReadCrosshairConfigMap;
 import com.github.khanshoaib3.minecraft_access.utils.BaseScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
@@ -56,19 +57,35 @@ public class ReadCrosshairConfigMenu extends BaseScreen {
                 true);
         this.addDrawableChild(repeatSpeakingIntervalButton);
 
-        Function<Boolean, String> enablePartialSpeakingText = featureToggleButtonMessageWith("minecraft_access.gui.read_crosshair_config_menu.button.partial_speaking_button");
-        ButtonWidget enablePartialSpeakingButton = this.buildButtonWidget(
-                  enablePartialSpeakingText.apply(map.isEnablePartialSpeaking()),
+        ButtonWidget enablePartialSpeakingButton = this.buildButtonWidget("minecraft_access.gui.read_crosshair_config_menu.button.partial_speaking_menu_button",
+                (button) -> this.client.setScreen(new RCPartialSpeakingConfigMenu("rc_partial_speaking_menu", this)));
+        this.addDrawableChild(enablePartialSpeakingButton);
+    }
+}
+
+class RCPartialSpeakingConfigMenu extends BaseScreen {
+
+    public RCPartialSpeakingConfigMenu(String title, BaseScreen previousScreen) {
+        super(title, previousScreen);
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+
+        RCPartialSpeakingConfigMap map = RCPartialSpeakingConfigMap.getInstance();
+
+        ButtonWidget featureToggleButton = this.buildButtonWidget(featureToggleButtonMessage(map.isEnabled()),
                 (button) -> {
-                    map.setEnablePartialSpeaking(!map.isEnablePartialSpeaking());
-                    button.setMessage(Text.of(enablePartialSpeakingText.apply(map.isEnablePartialSpeaking())));
+                    map.setEnabled(!map.isEnabled());
+                    button.setMessage(Text.of(featureToggleButtonMessage(map.isEnabled())));
                     Config.getInstance().writeJSON();
                 });
-        this.addDrawableChild(enablePartialSpeakingButton);
+        this.addDrawableChild(featureToggleButton);
 
-        Function<Boolean, String> partialSpeakingWhitelistModeText = featureToggleButtonMessageWith("minecraft_access.gui.read_crosshair_config_menu.button.partial_speaking_whitelist_mode_button");
+        Function<Boolean, String> partialSpeakingWhitelistModeText = featureToggleButtonMessageWith("minecraft_access.gui.rc_partial_speaking_menu.button.partial_speaking_whitelist_mode_button");
         ButtonWidget partialSpeakingWhitelistModeButton = this.buildButtonWidget(
-                  partialSpeakingWhitelistModeText.apply(map.isPartialSpeakingWhitelistMode()),
+                partialSpeakingWhitelistModeText.apply(map.isPartialSpeakingWhitelistMode()),
                 (button) -> {
                     map.setPartialSpeakingWhitelistMode(!map.isPartialSpeakingWhitelistMode());
                     button.setMessage(Text.of(partialSpeakingWhitelistModeText.apply(map.isPartialSpeakingWhitelistMode())));
@@ -76,9 +93,9 @@ public class ReadCrosshairConfigMenu extends BaseScreen {
                 });
         this.addDrawableChild(partialSpeakingWhitelistModeButton);
 
-        Function<Boolean, String> partialSpeakingFuzzyModeText = featureToggleButtonMessageWith("minecraft_access.gui.read_crosshair_config_menu.button.partial_speaking_fuzzy_mode_button");
+        Function<Boolean, String> partialSpeakingFuzzyModeText = featureToggleButtonMessageWith("minecraft_access.gui.rc_partial_speaking_menu.button.partial_speaking_fuzzy_mode_button");
         ButtonWidget partialSpeakingFuzzyModeButton = this.buildButtonWidget(
-                  partialSpeakingFuzzyModeText.apply(map.isPartialSpeakingFuzzyMode()),
+                partialSpeakingFuzzyModeText.apply(map.isPartialSpeakingFuzzyMode()),
                 (button) -> {
                     map.setPartialSpeakingFuzzyMode(!map.isPartialSpeakingFuzzyMode());
                     button.setMessage(Text.of(partialSpeakingFuzzyModeText.apply(map.isPartialSpeakingFuzzyMode())));

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
@@ -46,6 +46,8 @@ public class ReadCrosshair {
     private boolean partialSpeakingWhitelistMode;
     private boolean partialSpeakingFuzzyMode;
     private List<String> partialSpeakingTargets;
+    private boolean partialSpeakingBlock;
+    private boolean partialSpeakingEntity;
 
     public ReadCrosshair() {
         previousQuery = "";
@@ -97,6 +99,20 @@ public class ReadCrosshair {
         this.partialSpeakingFuzzyMode = map.isPartialSpeakingFuzzyMode();
         this.partialSpeakingWhitelistMode = map.isPartialSpeakingWhitelistMode();
         this.partialSpeakingTargets = map.getPartialSpeakingTargets();
+        switch (map.getPartialSpeakingTargetMode()) {
+            case ALL -> {
+                partialSpeakingBlock = true;
+                partialSpeakingEntity = true;
+            }
+            case BLOCK -> {
+                partialSpeakingBlock = true;
+                partialSpeakingEntity = false;
+            }
+            case ENTITY -> {
+                partialSpeakingBlock = false;
+                partialSpeakingEntity = true;
+            }
+        }
     }
 
     private void checkForBlockAndEntityHit(MinecraftClient minecraftClient, HitResult blockHit) {
@@ -112,7 +128,9 @@ public class ReadCrosshair {
         try {
             Entity entity = hit.getEntity();
 
-            if (checkIfPartialSpeakingFeatureDoNotAllowsSpeakingThis(EntityType.getId(entity.getType()))) return;
+            if (enablePartialSpeaking && partialSpeakingEntity) {
+                if (checkIfPartialSpeakingFeatureDoesNotAllowsSpeakingThis(EntityType.getId(entity.getType()))) return;
+            }
 
             String currentQuery = entity.getName().getString();
             if (entity instanceof AnimalEntity animalEntity) {
@@ -163,7 +181,9 @@ public class ReadCrosshair {
         BlockState blockState = clientWorld.getBlockState(blockPos);
         Block block = blockState.getBlock();
 
-        if (checkIfPartialSpeakingFeatureDoNotAllowsSpeakingThis(Registries.BLOCK.getId(block))) return;
+        if (enablePartialSpeaking && partialSpeakingBlock) {
+            if (checkIfPartialSpeakingFeatureDoesNotAllowsSpeakingThis(Registries.BLOCK.getId(block))) return;
+        }
 
         String name = block.getName().getString();
         String toSpeak = name;
@@ -416,20 +436,12 @@ public class ReadCrosshair {
         );
     }
 
-    private boolean checkIfPartialSpeakingFeatureDoNotAllowsSpeakingThis(Identifier id) {
+    private boolean checkIfPartialSpeakingFeatureDoesNotAllowsSpeakingThis(Identifier id) {
         if (id == null) return false;
-        String resourceLocation = id.getNamespace();
-
-        if (enablePartialSpeaking) {
-            Predicate<String> p = partialSpeakingFuzzyMode ?
-                    resourceLocation::contains :
-                    resourceLocation::equals;
-
-            return partialSpeakingWhitelistMode ?
-                    partialSpeakingTargets.stream().noneMatch(p) :
-                    partialSpeakingTargets.stream().anyMatch(p);
-        }
-
-        return false;
+        String name = id.getPath();
+        Predicate<String> p = partialSpeakingFuzzyMode ? name::contains : name::equals;
+        return partialSpeakingWhitelistMode ?
+                partialSpeakingTargets.stream().noneMatch(p) :
+                partialSpeakingTargets.stream().anyMatch(p);
     }
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
@@ -1,6 +1,7 @@
 package com.github.khanshoaib3.minecraft_access.features;
 
 import com.github.khanshoaib3.minecraft_access.MainClass;
+import com.github.khanshoaib3.minecraft_access.config.config_maps.RCPartialSpeakingConfigMap;
 import com.github.khanshoaib3.minecraft_access.config.config_maps.ReadCrosshairConfigMap;
 import com.github.khanshoaib3.minecraft_access.utils.PlayerPositionUtils;
 import com.github.khanshoaib3.minecraft_access.utils.TimeUtils;
@@ -89,17 +90,20 @@ public class ReadCrosshair {
     }
 
     private void loadConfigurations() {
-        ReadCrosshairConfigMap map = ReadCrosshairConfigMap.getInstance();
-        this.speakSide = map.isSpeakSide();
+        ReadCrosshairConfigMap rcMap = ReadCrosshairConfigMap.getInstance();
+        RCPartialSpeakingConfigMap rcpMap = rcMap.getPartialSpeakingConfigMap();
+
+        this.speakSide = rcMap.isSpeakSide();
         // affirmation for easier use
-        this.speakingConsecutiveBlocks = !map.isDisableSpeakingConsecutiveBlocks();
-        long interval = map.getRepeatSpeakingInterval();
+        this.speakingConsecutiveBlocks = !rcMap.isDisableSpeakingConsecutiveBlocks();
+        long interval = rcMap.getRepeatSpeakingInterval();
         this.repeatSpeakingInterval = TimeUtils.Interval.inMilliseconds(interval, this.repeatSpeakingInterval);
-        this.enablePartialSpeaking = map.isEnablePartialSpeaking();
-        this.partialSpeakingFuzzyMode = map.isPartialSpeakingFuzzyMode();
-        this.partialSpeakingWhitelistMode = map.isPartialSpeakingWhitelistMode();
-        this.partialSpeakingTargets = map.getPartialSpeakingTargets();
-        switch (map.getPartialSpeakingTargetMode()) {
+
+        this.enablePartialSpeaking = rcpMap.isEnabled();
+        this.partialSpeakingFuzzyMode = rcpMap.isPartialSpeakingFuzzyMode();
+        this.partialSpeakingWhitelistMode = rcpMap.isPartialSpeakingWhitelistMode();
+        this.partialSpeakingTargets = rcpMap.getPartialSpeakingTargets();
+        switch (rcpMap.getPartialSpeakingTargetMode()) {
             case ALL -> {
                 partialSpeakingBlock = true;
                 partialSpeakingEntity = true;

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
@@ -27,6 +27,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
+
 /**
  * This feature reads the name of the targeted block or entity.<br>
  * It also gives feedback when a block is powered by a redstone signal or when a door is open similar cases.
@@ -36,6 +38,10 @@ public class ReadCrosshair {
     private boolean speakSide;
     private boolean speakingConsecutiveBlocks;
     private TimeUtils.Interval repeatSpeakingInterval;
+    private boolean enablePartialSpeaking;
+    private boolean partialSpeakingWhitelistMode;
+    private boolean partialSpeakingFuzzyMode;
+    private List<String> partialSpeakingTargets;
 
     public ReadCrosshair() {
         previousQuery = "";
@@ -77,12 +83,16 @@ public class ReadCrosshair {
     }
 
     private void loadConfigurations() {
-        ReadCrosshairConfigMap map = MainClass.config.getConfigMap().getReadCrosshairConfigMap();
+        ReadCrosshairConfigMap map = ReadCrosshairConfigMap.getInstance();
         this.speakSide = map.isSpeakSide();
         // affirmation for easier use
         this.speakingConsecutiveBlocks = !map.isDisableSpeakingConsecutiveBlocks();
         long interval = map.getRepeatSpeakingInterval();
         this.repeatSpeakingInterval = TimeUtils.Interval.inMilliseconds(interval, this.repeatSpeakingInterval);
+        this.enablePartialSpeaking = map.isEnablePartialSpeaking();
+        this.partialSpeakingFuzzyMode = map.isPartialSpeakingFuzzyMode();
+        this.partialSpeakingWhitelistMode = map.isPartialSpeakingWhitelistMode();
+        this.partialSpeakingTargets = map.getPartialSpeakingTargets();
     }
 
     private void checkForBlockAndEntityHit(MinecraftClient minecraftClient, HitResult blockHit) {

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/BaseScreen.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/BaseScreen.java
@@ -1,5 +1,6 @@
 package com.github.khanshoaib3.minecraft_access.utils;
 
+import com.github.khanshoaib3.minecraft_access.MainClass;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;
@@ -75,15 +76,20 @@ public class BaseScreen extends Screen {
         if (this.client != null) this.client.setScreen(previousScreen);
     }
 
-    protected static String translateFeatureToggleButtonMessage(boolean enabled) {
+    protected static String featureToggleButtonMessage(boolean enabled) {
         return I18n.translate("minecraft_access.gui.common.button.feature_toggle_button." + (enabled ? "enabled" : "disabled"));
     }
 
     /**
      * A reusable function for calculating feature toggle button message.
      */
-    protected static Function<Boolean, String> buildFeatureToggleButtonMessageTranslator(String buttonTranslationKey) {
+    protected static Function<Boolean, String> featureToggleButtonMessageWith(String buttonTranslationKey) {
         return (Boolean b) -> I18n.translate("minecraft_access.gui.common.button.toggle_button." + (b ? "enabled" : "disabled"),
                 I18n.translate(buttonTranslationKey));
+    }
+
+    protected static String floatValueButtonMessageWith(String buttonTranslationKey, double value) {
+        return I18n.translate("minecraft_access.gui.common.button.button_with_float_value",
+                I18n.translate(buttonTranslationKey), value);
     }
 }


### PR DESCRIPTION
with https://github.com/khanshoaib3/minecraft-access-i18n/pull/11
close #68 

* Add five new configs to `Read Crosshair`.
* Fix [a wrongly configing](https://github.com/khanshoaib3/minecraft-access/commit/3181cad4e8bb4e2fca67a7d3a6b616b1072242b1#diff-167fb5759425be675512942d5cd0706844fd654939f6a5f6ec3d3a6940a68202) in `ReadCrossConfigMenu` (`SpeakSide` -> `DisableSpeakingConsecutiveBlocks`).
* Refactor the `ReadCrossConfigMap` into singleton pattern.