### PR TITLE
Fix book edit screen tab switching buttons feature in 1.20.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,14 @@ Narrates when the player xp level is increased or decreased.
 
 Adds the item durability into the tooltip.
 
+## Book Editing
+
+Press Use key while holding a [Book and Quill](https://minecraft.fandom.com/wiki/Book_and_Quill) item to open the book editing screen.
+Press Tab key to select buttons, while button is focused, press Space key or Left Mouse key to click it (space can be inputted as text when no button is focused).
+Press Page Up and Page Down Key to switch between pages.
+Press "Done" button to save your unfinished work and quit editing screen.
+Press "Sign" button and enter a title for the book to make it permanently non-editable.
+
 # Mod Configuration
 
 The mod can be configured in two ways: using the config menu or directly editing the config.json file.

--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ any other key with same key.*
 9. Left Shift + Switch Tab Key = Select previous tab (only for creative inventory screen and inventory/crafting screen).
 10. Toggle Craftable Key (default: R) = Toggle between show all and show only craftable recipes in inventory/crafting
     screen.
-11. Left Mouse Click Sim Key (default: [) = Simulates left mouse click.
-12. Right Mouse Click Sim Key (default: ]) = Simulates right mouse click.
-13. T Key (not re-mappable) = Select the search box.
-14. Enter Key (not re-mappable) = Deselect the search box.
+11. Left Shift + Up Key = Select previous page of the Recipe Book. (active when recipe book group is selected).
+12. Left Shift + Down Key = Select next page of the Recipe Book. (active when recipe book group is selected).
+13. Left Mouse Click Sim Key (default: [) = Simulates left mouse click.
+14. Right Mouse Click Sim Key (default: ]) = Simulates right mouse click.
+15. T Key (not re-mappable) = Select the search box.
+16. Enter Key (not re-mappable) = Deselect the search box.
 
 **Configuration Options:-**
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/inventory_controls/InventoryControls.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/inventory_controls/InventoryControls.java
@@ -19,6 +19,7 @@ import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemGroups;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.MathHelper;
+import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.glfw.GLFW;
 
@@ -145,7 +146,9 @@ public class InventoryControls {
 
             if (!previousSlotText.equals(getCurrentSlotNarrationText())) {
                 previousSlotText = getCurrentSlotNarrationText();
-                MainClass.speakWithNarrator(previousSlotText, true);
+                if (Strings.isNotBlank(previousSlotText)) {
+                    MainClass.speakWithNarrator(previousSlotText, true);
+                }
             }
 
             if(wasAnyKeyPressed) interval.start();

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonMixin.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonMixin.java
@@ -1,26 +1,58 @@
 package com.github.khanshoaib3.minecraft_access.mixin;
 
 import com.github.khanshoaib3.minecraft_access.MainClass;
+import com.github.khanshoaib3.minecraft_access.utils.MouseUtils;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.screen.recipebook.AnimatedResultButton;
+import net.minecraft.client.resource.language.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.DynamicRegistryManager;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(AnimatedResultButton.class)
 public class AnimatedResultButtonMixin {
-//    @Inject(at = @At("HEAD"), method = "appendNarrations", cancellable = true) // Pre 1.19.3
+    @Unique
+    boolean minecraft_access$vibratingFlag = false;
+
+    @Unique
+    String minecraft_access$previousItemName = "";
+
+    //    @Inject(at = @At("HEAD"), method = "appendNarrations", cancellable = true) // Pre 1.19.3
     @Inject(at = @At("HEAD"), method = "appendClickableNarrations", cancellable = true) // From 1.19.3
     private void appendNarrations(NarrationMessageBuilder builder, CallbackInfo callbackInfo) {
-        //TODO re-check if it still works
         ItemStack itemStack = ((AnimatedResultButtonAccessor) this).callGetResults().get(((AnimatedResultButtonAccessor) this).getCurrentResultIndex()).getOutput(DynamicRegistryManager.EMPTY);
-        String toSpeak = "%s %d %s".formatted(((AnimatedResultButtonAccessor) this).getResultCollection().hasCraftableRecipes() ? "Craftable" : "Not craftable", itemStack.getCount(), itemStack.getName().getString());
+        String itemName = itemStack.getName().getString();
 
-        MainClass.speakWithNarrator(toSpeak, true);
+        if (!itemName.equalsIgnoreCase(minecraft_access$previousItemName)) {
+            String craftable = ((AnimatedResultButtonAccessor) this).getResultCollection().hasCraftableRecipes() ? "craftable" : "not_craftable";
+            craftable = I18n.translate("minecraft_access.other." + craftable);
+            String toSpeak = "%s %d %s".formatted(craftable, itemStack.getCount(), itemName);
+            MainClass.speakWithNarrator(toSpeak, true);
+            minecraft_access$previousItemName = itemName;
+        }
 
+        minecraft_access$shakeTheMouse();
         callbackInfo.cancel();
+    }
+
+    /**
+     * It seems the "appendNarrations" will be invoked after every mouse moving.
+     * Keep moving the mouse to trigger this method to read different items in same animated button.
+     * It's not a solution that gets to the root of the problem, but I think it's simpler and more stable.
+     * This method doesn't affect slot moving inside recipe book group.
+     */
+    @Unique
+    private void minecraft_access$shakeTheMouse() {
+        // the width and height of one animated button are both 25.
+        int offset = this.minecraft_access$vibratingFlag ? 12 : 13;
+        int x = ((ClickableWidgetAccessor) this).callGetX() + offset;
+        int y = ((ClickableWidgetAccessor) this).callGetY() + offset;
+        MouseUtils.Coordinates p = MouseUtils.calcRealPositionOfWidget(x, y);
+        MouseUtils.move(p.x(), p.y());
+        this.minecraft_access$vibratingFlag = !this.minecraft_access$vibratingFlag;
     }
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/BookEditScreenMixin.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/BookEditScreenMixin.java
@@ -2,13 +2,16 @@ package com.github.khanshoaib3.minecraft_access.mixin;
 
 import com.github.khanshoaib3.minecraft_access.MainClass;
 import com.github.khanshoaib3.minecraft_access.utils.KeyUtils;
+import com.github.khanshoaib3.minecraft_access.utils.MouseUtils;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.BookEditScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.PageTurnWidget;
+import net.minecraft.client.resource.language.I18n;
 import net.minecraft.text.Text;
+import org.lwjgl.glfw.GLFW;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -20,7 +23,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.List;
 
 @Mixin(BookEditScreen.class)
-public class BookEditScreenMixin {
+public abstract class BookEditScreenMixin {
     @Shadow private int currentPage;
     @Final @Shadow private List<String> pages;
 
@@ -42,32 +45,52 @@ public class BookEditScreenMixin {
     @Unique boolean minecraft_access$firstTimeInSignMenu = true;
     @Unique String minecraft_access$previousContent = "";
 
+    @Unique private boolean minecraft_access$isTabPressedPreviousTick = false;
+    @Unique private boolean minecraft_access$isSpacePressedPreviousTick = false;
+    @Unique private int minecraft_access$currentFocusedButtonStateCode = 0;
+    @Unique private static final int BUTTON_OFFSET = 3;
+
     @Inject(at = @At("HEAD"), method = "render")
     public void render(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         MinecraftClient minecraftClient = MinecraftClient.getInstance();
         if (minecraftClient == null) return;
         if (minecraftClient.currentScreen == null) return;
 
-        boolean isSpaceOrEnterPressed = KeyUtils.isEnterPressed() || KeyUtils.isSpacePressed();
+        boolean isSpacePressed = KeyUtils.isSpacePressed();
+        boolean isTabPressed = KeyUtils.isAnyPressed(GLFW.GLFW_KEY_TAB);
 
-        if (isSpaceOrEnterPressed) {
-            if (this.cancelButton.isFocused()) {
-                this.cancelButton.onPress();
-                return;
-            }
-            if (this.finalizeButton.isFocused()) {
-                this.finalizeButton.onPress();
-                return;
-            }
-            if (this.doneButton.isFocused()) {
-                this.doneButton.onPress();
-                return;
-            }
-            if (this.signButton.isFocused()) {
-                this.signButton.onPress();
-                return;
+        // Switch between buttons with Tab key
+        // Only switch once until release and press Tab again
+        if (isTabPressed && !minecraft_access$isTabPressedPreviousTick) {
+            minecraft_access$switchMouseHoveredButton();
+        }
+        // update the state
+        minecraft_access$isTabPressedPreviousTick = isTabPressed;
+
+        if (isSpacePressed && !minecraft_access$isSpacePressedPreviousTick) {
+            minecraft_access$isSpacePressedPreviousTick = true;
+            if (this.signing) {
+                if (this.cancelButton.isHovered()) {
+                    this.cancelButton.onPress();
+                    return;
+                }
+                if (this.finalizeButton.isHovered()) {
+                    this.finalizeButton.onPress();
+                    return;
+                }
+            } else {
+                if (this.doneButton.isHovered()) {
+                    this.doneButton.onPress();
+                    return;
+                }
+                if (this.signButton.isHovered()) {
+                    this.signButton.onPress();
+                    return;
+                }
             }
         }
+        // update the state
+        minecraft_access$isSpacePressedPreviousTick = isSpacePressed;
 
         if (this.signing) {
             String currentTitle = this.title.trim();
@@ -101,5 +124,55 @@ public class BookEditScreenMixin {
             minecraft_access$previousContent = currentPageContentString;
             MainClass.speakWithNarrator(currentPageContentString, true);
         }
+    }
+
+    /**
+     * Switch buttons focus with Tab key,
+     * put the cursor on the focused button instead of invoking "setFocused()",
+     * since somewhere we don't know will modify buttons focus states, which affects our logic.
+     */
+    @Unique
+    private void minecraft_access$switchMouseHoveredButton() {
+        if (this.signing) {
+            // finalizeButton & cancelButton under the screen
+            switch (minecraft_access$currentFocusedButtonStateCode) {
+                case 0 -> minecraft_access$hoverMouseOnTo(this.cancelButton);
+                case 1 -> minecraft_access$moveMouseAway();
+                case 2 -> {
+                    // the finalizeButton only be activated while title is not empty
+                    if (this.finalizeButton.active) {
+                        minecraft_access$hoverMouseOnTo(this.finalizeButton);
+                    } else {
+                        minecraft_access$currentFocusedButtonStateCode = 0;
+                        minecraft_access$hoverMouseOnTo(this.cancelButton);
+                    }
+                }
+            }
+        } else {
+            // signButton & doneButton under the screen
+            switch (minecraft_access$currentFocusedButtonStateCode) {
+                case 0 -> minecraft_access$hoverMouseOnTo(this.signButton);
+                case 1 -> minecraft_access$hoverMouseOnTo(this.doneButton);
+                case 2 -> minecraft_access$moveMouseAway();
+            }
+        }
+
+        // loop between three status
+        minecraft_access$currentFocusedButtonStateCode = (minecraft_access$currentFocusedButtonStateCode + 1) % 3;
+    }
+
+    @Unique
+    private void minecraft_access$hoverMouseOnTo(ButtonWidget button) {
+        MouseUtils.performAt(((ClickableWidgetAccessor) button).callGetX() + BUTTON_OFFSET,
+                ((ClickableWidgetAccessor) button).callGetY() + BUTTON_OFFSET,
+                MouseUtils::move);
+    }
+
+    @Unique
+    private void minecraft_access$moveMouseAway() {
+        MouseUtils.performAt(((ClickableWidgetAccessor) this.signButton).callGetX() - 10,
+                ((ClickableWidgetAccessor) this.signButton).callGetY() - 10,
+                MouseUtils::move);
+        MainClass.speakWithNarrator(I18n.translate("minecraft_access.book_edit.focus_moved_away"), true);
     }
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/BookEditScreenMixin.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/BookEditScreenMixin.java
@@ -12,6 +12,7 @@ import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -37,8 +38,9 @@ public class BookEditScreenMixin {
     @Shadow private ButtonWidget doneButton;
 
     @Shadow private String title;
-    boolean firstTimeInSignMenu = true;
-    String previousContent = "";
+
+    @Unique boolean minecraft_access$firstTimeInSignMenu = true;
+    @Unique String minecraft_access$previousContent = "";
 
     @Inject(at = @At("HEAD"), method = "render")
     public void render(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
@@ -48,46 +50,45 @@ public class BookEditScreenMixin {
 
         boolean isSpaceOrEnterPressed = KeyUtils.isEnterPressed() || KeyUtils.isSpacePressed();
 
-        if (this.cancelButton.isFocused() && isSpaceOrEnterPressed) {
-            this.cancelButton.onPress();
-            return;
-        }
-
-        if (this.finalizeButton.isFocused() && isSpaceOrEnterPressed) {
-            this.finalizeButton.onPress();
-            return;
-        }
-
-        if (this.doneButton.isFocused() && isSpaceOrEnterPressed) {
-            this.doneButton.onPress();
-            return;
-        }
-
-        if (this.signButton.isFocused() && isSpaceOrEnterPressed) {
-            this.signButton.onPress();
-            return;
+        if (isSpaceOrEnterPressed) {
+            if (this.cancelButton.isFocused()) {
+                this.cancelButton.onPress();
+                return;
+            }
+            if (this.finalizeButton.isFocused()) {
+                this.finalizeButton.onPress();
+                return;
+            }
+            if (this.doneButton.isFocused()) {
+                this.doneButton.onPress();
+                return;
+            }
+            if (this.signButton.isFocused()) {
+                this.signButton.onPress();
+                return;
+            }
         }
 
         if (this.signing) {
             String currentTitle = this.title.trim();
 
-            if (!previousContent.equals(currentTitle)) {
-                previousContent = currentTitle;
-                if(firstTimeInSignMenu){
-                    firstTimeInSignMenu = false;
+            if (!minecraft_access$previousContent.equals(currentTitle)) {
+                minecraft_access$previousContent = currentTitle;
+                if (minecraft_access$firstTimeInSignMenu) {
+                    minecraft_access$firstTimeInSignMenu = false;
                     currentTitle = FINALIZE_WARNING_TEXT.getString() + "\n" + EDIT_TITLE_TEXT.getString();
                 }
                 MainClass.speakWithNarrator(currentTitle, true);
             }
             return;
         }
-        firstTimeInSignMenu = true;
+        minecraft_access$firstTimeInSignMenu = true;
 
         // Repeat current page content and un-focus next and previous page buttons
         if (Screen.hasAltDown() && Screen.hasControlDown()) {
             if (this.nextPageButton.isFocused()) this.nextPageButton.setFocused(false);
             if (this.previousPageButton.isFocused()) this.previousPageButton.setFocused(false);
-            previousContent = "";
+            minecraft_access$previousContent = "";
         }
 
         if (this.currentPage < 0 || this.currentPage > this.pages.size())
@@ -96,8 +97,8 @@ public class BookEditScreenMixin {
         String currentPageContentString = this.pages.get(this.currentPage).trim();
         currentPageContentString = "%s \n\n %s".formatted(currentPageContentString, this.pageIndicatorText.getString());
 
-        if (!previousContent.equals(currentPageContentString)) {
-            previousContent = currentPageContentString;
+        if (!minecraft_access$previousContent.equals(currentPageContentString)) {
+            minecraft_access$previousContent = currentPageContentString;
             MainClass.speakWithNarrator(currentPageContentString, true);
         }
     }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/ClickableWidgetAccessor.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/ClickableWidgetAccessor.java
@@ -4,9 +4,16 @@ import net.minecraft.client.gui.widget.ClickableWidget;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(ClickableWidget.class)
 public interface ClickableWidgetAccessor {
     @Accessor
     void setMessage(Text message);
+
+    @Invoker
+    int callGetX();
+
+    @Invoker
+    int callGetY();
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/MouseUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/MouseUtils.java
@@ -9,6 +9,7 @@ import net.minecraft.client.util.Window;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 /**
  * Contains functions to simulate mouse events.
@@ -40,6 +41,7 @@ public class MouseUtils {
      * @param x the x position of the pixel location
      * @param y the y position of the pixel location
      */
+    @SuppressWarnings("unused")
     public static void moveAndRightClick(int x, int y) {
         move(x, y);
         // fix the https://github.com/khanshoaib3/minecraft-access/issues/65
@@ -224,11 +226,26 @@ public class MouseUtils {
         return new Coordinates(realX, realY);
     }
 
+    public static void move(Coordinates coordinates) {
+        move(coordinates.x(), coordinates.y());
+    }
+
+    /**
+     * Preform a mouse event at the given location
+     *
+     * @param x        x coordinate
+     * @param y        y coordinate
+     * @param consumer event
+     */
+    public static void performAt(int x, int y, Consumer<Coordinates> consumer) {
+        consumer.accept(calcRealPositionOfWidget(x, y));
+    }
+
     /**
      * Initializes the User32.dll for windows
      */
     private static void initializeUser32dll() {
-        if(!OsUtils.isWindows())
+        if (!OsUtils.isWindows())
             return;
 
         try {


### PR DESCRIPTION
The `Enter` key will trigger the sign action while screen is in `signing` state, so I removed it.
Add a config text: https://github.com/khanshoaib3/minecraft-access-i18n/pull/13