### PR TITLE
Minor fixes for 1.20.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ This feature adds the following key bindings to control the camera through the k
 ## Inventory Controls
 
 This features lets us use keyboard in inventory screens. Works with all default minecraft screens.
+Please note that item speaking in "Scrollable Recipes Group" under "Crafting Screen" will be delayed about one second,
+wait after press the slot moving key to hear the item name.
 
 *All key binds are re-mappable(except two keys) from the game's controls menu and these key binds do not interrupt with
 any other key with same key.*
@@ -287,5 +289,7 @@ or [Code Beautify Json Online Editor](https://jsonformatter.org/json-editor).
 # Known Issues
 
 1. The default narrator speaks even if the narrator is turned off.
-2. (Linux only) xdotool is not recognised even if it is installed.
-3. (Linux only) Minecraft says not narrator available even if flite is installed.
+2. In "Scrollable Recipes Group" under "Crafting Screen", sometimes you will move into empty slots and the mod won't speak out "Empty Slot" as it does in "Inventory Group", it speaks nothing.
+   In this case, move towards left and up until you hear some items name.
+3. (Linux only) xdotool is not recognised even if it is installed.
+4. (Linux only) Minecraft says not narrator available even if flite is installed.

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ any other key with same key.*
 9. Left Shift + Switch Tab Key = Select previous tab (only for creative inventory screen and inventory/crafting screen).
 10. Toggle Craftable Key (default: R) = Toggle between show all and show only craftable recipes in inventory/crafting
     screen.
-11. Left Shift + Up Key = Select previous page of the Recipe Book. (active when recipe book group is selected).
-12. Left Shift + Down Key = Select next page of the Recipe Book. (active when recipe book group is selected).
+11. Left Shift + Up Key = Select previous page of the Recipe Book. (only for creative inventory screen and inventory/crafting screen).
+12. Left Shift + Down Key = Select next page of the Recipe Book. (only for creative inventory screen and inventory/crafting screen).
 13. Left Mouse Click Sim Key (default: [) = Simulates left mouse click.
 14. Right Mouse Click Sim Key (default: ]) = Simulates right mouse click.
 15. T Key (not re-mappable) = Select the search box.

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
@@ -270,7 +270,15 @@ public class ReadCrosshair {
         boolean isEmittingPower = world.isEmittingRedstonePower(blockPos, Direction.DOWN);
         boolean isReceivingPower = world.isReceivingRedstonePower(blockPos);
 
-        if ((block instanceof RedstoneWireBlock || block instanceof PistonBlock || block instanceof GlowLichenBlock || block instanceof RedstoneLampBlock) && (isReceivingPower || isEmittingPower)) {
+        if (block instanceof PistonBlock) {
+            String facing = blockState.get(PistonBlock.FACING).getName();
+            toSpeak = I18n.translate("minecraft_access.read_crosshair.facing", toSpeak, I18n.translate("minecraft_access.direction." + facing));
+            currentQuery += "facing " + facing;
+            if (isReceivingPower) {
+                toSpeak = I18n.translate("minecraft_access.read_crosshair.powered", toSpeak);
+                currentQuery += "powered";
+            }
+        } else if ((block instanceof RedstoneWireBlock || block instanceof GlowLichenBlock || block instanceof RedstoneLampBlock) && (isReceivingPower || isEmittingPower)) {
             toSpeak = I18n.translate("minecraft_access.read_crosshair.powered", toSpeak);
             currentQuery += "powered";
 //        } else if ((block instanceof RedstoneTorchBlock || block instanceof LeverBlock || block instanceof AbstractButtonBlock) && isEmittingPower) { // pre 1.19.3

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonMixin.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonMixin.java
@@ -2,6 +2,7 @@ package com.github.khanshoaib3.minecraft_access.mixin;
 
 import com.github.khanshoaib3.minecraft_access.MainClass;
 import com.github.khanshoaib3.minecraft_access.utils.MouseUtils;
+import com.github.khanshoaib3.minecraft_access.utils.TimeUtils;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.screen.recipebook.AnimatedResultButton;
 import net.minecraft.client.resource.language.I18n;
@@ -21,18 +22,27 @@ public class AnimatedResultButtonMixin {
     @Unique
     String minecraft_access$previousItemName = "";
 
+    @Unique
+    private final TimeUtils.Interval minecraft_access$interval = TimeUtils.Interval.inMilliseconds(5000);
+
     //    @Inject(at = @At("HEAD"), method = "appendNarrations", cancellable = true) // Pre 1.19.3
     @Inject(at = @At("HEAD"), method = "appendClickableNarrations", cancellable = true) // From 1.19.3
     private void appendNarrations(NarrationMessageBuilder builder, CallbackInfo callbackInfo) {
         ItemStack itemStack = ((AnimatedResultButtonAccessor) this).callGetResults().get(((AnimatedResultButtonAccessor) this).getCurrentResultIndex()).getOutput(DynamicRegistryManager.EMPTY);
         String itemName = itemStack.getName().getString();
 
-        if (!itemName.equalsIgnoreCase(minecraft_access$previousItemName)) {
+        boolean sameItem = itemName.equalsIgnoreCase(minecraft_access$previousItemName);
+        if (!sameItem || minecraft_access$interval.isReady()) {
             String craftable = ((AnimatedResultButtonAccessor) this).getResultCollection().hasCraftableRecipes() ? "craftable" : "not_craftable";
             craftable = I18n.translate("minecraft_access.other." + craftable);
             String toSpeak = "%s %d %s".formatted(craftable, itemStack.getCount(), itemName);
             MainClass.speakWithNarrator(toSpeak, true);
+        }
+
+        // update the states
+        if (!sameItem) {
             minecraft_access$previousItemName = itemName;
+            minecraft_access$interval.reset();
         }
 
         minecraft_access$shakeTheMouse();

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonMixin.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonMixin.java
@@ -31,8 +31,7 @@ public class AnimatedResultButtonMixin {
             String craftable = ((AnimatedResultButtonAccessor) this).getResultCollection().hasCraftableRecipes() ? "craftable" : "not_craftable";
             craftable = I18n.translate("minecraft_access.other." + craftable);
             String toSpeak = "%s %d %s".formatted(craftable, itemStack.getCount(), itemName);
-            // Let the item speaking not interrupt the "recipe book group selected" speaking
-            MainClass.speakWithNarrator(toSpeak, false);
+            MainClass.speakWithNarrator(toSpeak, true);
             minecraft_access$previousItemName = itemName;
         }
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonMixin.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonMixin.java
@@ -31,7 +31,8 @@ public class AnimatedResultButtonMixin {
             String craftable = ((AnimatedResultButtonAccessor) this).getResultCollection().hasCraftableRecipes() ? "craftable" : "not_craftable";
             craftable = I18n.translate("minecraft_access.other." + craftable);
             String toSpeak = "%s %d %s".formatted(craftable, itemStack.getCount(), itemName);
-            MainClass.speakWithNarrator(toSpeak, true);
+            // Let the item speaking not interrupt the "recipe book group selected" speaking
+            MainClass.speakWithNarrator(toSpeak, false);
             minecraft_access$previousItemName = itemName;
         }
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/InGameHudMixin.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/InGameHudMixin.java
@@ -10,6 +10,7 @@ import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -25,6 +26,9 @@ public class InGameHudMixin {
     @Shadow
     private ItemStack currentStack;
 
+    @Unique
+    private String minecraft_access$previousContent = "";
+
     @Inject(at = @At("TAIL"), method = "renderHeldItemTooltip")
     public void renderHeldItemTooltipMixin(DrawContext context, CallbackInfo ci) {
         if (this.heldItemTooltipFade == 38 && !this.currentStack.isEmpty()) {
@@ -33,7 +37,12 @@ public class InGameHudMixin {
                     .append(" ")
                     .append(this.currentStack.getName())
                     .formatted(this.currentStack.getRarity().formatting);
-            MainClass.speakWithNarrator(I18n.translate("minecraft_access.other.hotbar", mutableText.getString()), true);
+
+            String toSpeak = mutableText.getString();
+            if (!this.minecraft_access$previousContent.equals(toSpeak)) {
+                MainClass.speakWithNarrator(I18n.translate("minecraft_access.other.hotbar", toSpeak), true);
+                this.minecraft_access$previousContent = toSpeak;
+            }
         }
     }
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/InGameHudMixin.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/InGameHudMixin.java
@@ -5,7 +5,6 @@ import com.github.khanshoaib3.minecraft_access.MainClass;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.client.resource.language.I18n;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
@@ -28,9 +27,10 @@ public class InGameHudMixin {
 
     @Inject(at = @At("TAIL"), method = "renderHeldItemTooltip")
     public void renderHeldItemTooltipMixin(DrawContext context, CallbackInfo ci) {
-        if (this.heldItemTooltipFade == 38 && !this.currentStack.isEmpty()/*FIXME && Config.get(Config.getHelditemnarratorkey())*/) {
+        if (this.heldItemTooltipFade == 38 && !this.currentStack.isEmpty()) {
             MutableText mutableText = net.minecraft.text.Text.empty()
                     .append(String.valueOf(this.currentStack.getCount()))
+                    .append(" ")
                     .append(this.currentStack.getName())
                     .formatted(this.currentStack.getRarity().formatting);
             MainClass.speakWithNarrator(I18n.translate("minecraft_access.other.hotbar", mutableText.getString()), true);


### PR DESCRIPTION
1. Fix the number of item and the first word of item name weren't separated with space.
2. Fix in README that both recipe books in survival mode crafting screen inventory screen and creative mode inventory screen can be scrolled with Left Shift Key + Up Key and Down Key.
3. Fix sometimes the item in crafting recipe book won't be spoken by the narrator, by adding five seconds repeat speaking interval.
4. Fix that selected items in hotbar will be spoken three times each time.
5. Add facing info for PistonBlock in ReadCrosshair.

~~Let the item speaking not interrupt the "recipe book group selected" speaking.~~ The fix will cause delay speaking on current item, which is unreceiving, so I reverted the commit.