### PR TITLE
Fix simulate mouse with keyboard

### DIFF
--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/MouseUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/MouseUtils.java
@@ -57,23 +57,12 @@ public class MouseUtils {
      * @param y the y position of the pixel location
      */
     public static void move(int x, int y) {
-        try {
-            MainClass.infoLog("Moving mouse to x:%d y:%d".formatted(x, y));
-
-            if (OsUtils.isLinux()) {
-                Runtime.getRuntime().exec("xdotool mousemove %d %d".formatted(x, y));
-            }
-
-            if (OsUtils.isWindows()) {
-                if (mainInterface == null) initializeUser32dll();
-
-                if (!mainInterface.SetCursorPos(x, y))
-                    MainClass.errorLog("\nError encountered on moving mouse.");
-            }
-        } catch (Exception e) {
-            MainClass.errorLog("\nError encountered on moving mouse.");
-            e.printStackTrace();
-        }
+        doNativeMouseAction("mouse moving", true,
+                "xdotool mousemove %d %d".formatted(x, y),
+                (i) -> {
+                    if (!i.SetCursorPos(x, y)) MainClass.errorLog("\nError encountered on moving mouse.");
+                }
+        );
     }
 
     /**
@@ -102,28 +91,13 @@ public class MouseUtils {
      * Perform left click at the current pixel location.
      */
     public static void leftClick() {
-        MinecraftClient minecraftClient = MinecraftClient.getInstance();
-        if (minecraftClient == null)
-            return;
-
-        try {
-            int x = (int) minecraftClient.mouse.getX(), y = (int) minecraftClient.mouse.getY();
-            MainClass.infoLog("Performing left click at x:%d y:%d".formatted(x, y));
-
-            if (OsUtils.isLinux()) {
-                Runtime.getRuntime().exec("xdotool click 1");
-            }
-
-            if (OsUtils.isWindows()) {
-                if (mainInterface == null) initializeUser32dll();
-
-                mainInterface.mouse_event(MouseEventFlags.LEFTDOWN.getValue(), 0, 0, 0, 0);
-                mainInterface.mouse_event(MouseEventFlags.LEFTUP.getValue(), 0, 0, 0, 0);
-            }
-        } catch (Exception e) {
-            MainClass.errorLog("\nError encountered on performing left mouse click.");
-            e.printStackTrace();
-        }
+        doNativeMouseAction("left click", true,
+                "xdotool click 1",
+                (i) -> {
+                    i.mouse_event(MouseEventFlags.LEFTDOWN.getValue(), 0, 0, 0, 0);
+                    i.mouse_event(MouseEventFlags.LEFTUP.getValue(), 0, 0, 0, 0);
+                }
+        );
     }
 
 
@@ -131,106 +105,70 @@ public class MouseUtils {
      * Perform middle click at the current pixel location.
      */
     public static void middleClick() {
-        MinecraftClient minecraftClient = MinecraftClient.getInstance();
-        if (minecraftClient == null)
-            return;
-
-        try {
-            int x = (int) minecraftClient.mouse.getX(), y = (int) minecraftClient.mouse.getY();
-            MainClass.infoLog("Performing middle click at x:%d y:%d".formatted(x, y));
-
-            if (OsUtils.isLinux()) {
-                Runtime.getRuntime().exec("xdotool click 2");
-            }
-
-            if (OsUtils.isWindows()) {
-                if (mainInterface == null) initializeUser32dll();
-
-                mainInterface.mouse_event(MouseEventFlags.MIDDLEDOWN.getValue(), 0, 0, 0, 0);
-                mainInterface.mouse_event(MouseEventFlags.MIDDLEUP.getValue(), 0, 0, 0, 0);
-            }
-        } catch (Exception e) {
-            MainClass.errorLog("\nError encountered on performing middle mouse click.");
-            e.printStackTrace();
-        }
+        doNativeMouseAction("middle click", true,
+                "xdotool click 2",
+                (i) -> {
+                    i.mouse_event(MouseEventFlags.MIDDLEDOWN.getValue(), 0, 0, 0, 0);
+                    i.mouse_event(MouseEventFlags.MIDDLEUP.getValue(), 0, 0, 0, 0);
+                }
+        );
     }
 
     /**
      * Perform right click at the current pixel location.
      */
     public static void rightClick() {
-        MinecraftClient minecraftClient = MinecraftClient.getInstance();
-        if (minecraftClient == null)
-            return;
-
-        try {
-            int x = (int) minecraftClient.mouse.getX(), y = (int) minecraftClient.mouse.getY();
-            MainClass.infoLog("Performing right click at x:%d y:%d".formatted(x, y));
-
-            if (OsUtils.isLinux()) {
-                Runtime.getRuntime().exec("xdotool click 3");
-            }
-
-            if (OsUtils.isWindows()) {
-                if (mainInterface == null) initializeUser32dll();
-
-                mainInterface.mouse_event(MouseEventFlags.RIGHTDOWN.getValue(), 0, 0, 0, 0);
-                mainInterface.mouse_event(MouseEventFlags.RIGHTUP.getValue(), 0, 0, 0, 0);
-            }
-        } catch (Exception e) {
-            MainClass.errorLog("\nError encountered on performing right mouse click.");
-            e.printStackTrace();
-        }
+        doNativeMouseAction("right click", true,
+                "xdotool click 3",
+                (i) -> {
+                    i.mouse_event(MouseEventFlags.RIGHTDOWN.getValue(), 0, 0, 0, 0);
+                    i.mouse_event(MouseEventFlags.RIGHTUP.getValue(), 0, 0, 0, 0);
+                }
+        );
     }
 
     /**
      * Performs mouse scroll up
      */
-    public static void scrollUp(){
-        MinecraftClient minecraftClient = MinecraftClient.getInstance();
-        if (minecraftClient == null)
-            return;
-
-        try {
-            MainClass.infoLog("Performing scroll up");
-
-            if (OsUtils.isLinux()) {
-                Runtime.getRuntime().exec("xdotool click 4");
-            }
-
-            if (OsUtils.isWindows()) {
-                if (mainInterface == null) initializeUser32dll();
-
-                mainInterface.mouse_event(MouseEventFlags.WHEEL.getValue(), 0, 0, 120, 0);
-            }
-        } catch (Exception e) {
-            MainClass.errorLog("\nError encountered on performing scroll up.");
-            e.printStackTrace();
-        }
+    public static void scrollUp() {
+        doNativeMouseAction("scroll up", false,
+                "xdotool click 4",
+                (i) -> i.mouse_event(MouseEventFlags.WHEEL.getValue(), 0, 0, 120, 0)
+        );
     }
 
     /**
      * Performs mouse scroll down
      */
-    public static void scrollDown(){
+    public static void scrollDown() {
+        doNativeMouseAction("scroll down", false,
+                "xdotool click 5",
+                (i) -> i.mouse_event(MouseEventFlags.WHEEL.getValue(), 0, 0, -120, 0));
+    }
+
+    private static void doNativeMouseAction(String name, boolean logCoordinates, String linuxXdotCommand, Consumer<user32dllInterface> windowsAction) {
         MinecraftClient minecraftClient = MinecraftClient.getInstance();
         if (minecraftClient == null)
             return;
 
+
         try {
-            MainClass.infoLog("Performing scroll down");
+            String coordinates = "";
+            if (logCoordinates) {
+                int x = (int) minecraftClient.mouse.getX(), y = (int) minecraftClient.mouse.getY();
+                coordinates = " on x:%d y:%d".formatted(x, y);
+            }
+            MainClass.infoLog("Performing " + name + coordinates);
+
 
             if (OsUtils.isLinux()) {
-                Runtime.getRuntime().exec("xdotool click 5");
-            }
-
-            if (OsUtils.isWindows()) {
+                Runtime.getRuntime().exec(linuxXdotCommand);
+            } else if (OsUtils.isWindows()) {
                 if (mainInterface == null) initializeUser32dll();
-
-                mainInterface.mouse_event(MouseEventFlags.WHEEL.getValue(), 0, 0, -120, 0);
+                windowsAction.accept(mainInterface);
             }
         } catch (Exception e) {
-            MainClass.errorLog("\nError encountered on performing scroll up.");
+            MainClass.errorLog("\nError encountered on performing " + name + ".");
             e.printStackTrace();
         }
     }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/MouseUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/MouseUtils.java
@@ -9,6 +9,7 @@ import net.minecraft.client.util.Window;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 /**
  * Contains functions to simulate mouse events.
@@ -40,10 +41,14 @@ public class MouseUtils {
      * @param x the x position of the pixel location
      * @param y the y position of the pixel location
      */
+    @SuppressWarnings("unused")
     public static void moveAndRightClick(int x, int y) {
         move(x, y);
+        // fix the https://github.com/khanshoaib3/minecraft-access/issues/65
         if (OsUtils.isWindows()) {
             try {
+                // with a little bit of waiting, everything is ok now.
+                // I've tried to set the value to 10, and it doesn't always work, 20 is fine.
                 TimeUnit.MILLISECONDS.sleep(20);
             } catch (Exception ignored) {
             }
@@ -247,11 +252,28 @@ public class MouseUtils {
         return new Coordinates(realX, realY);
     }
 
+    @SuppressWarnings("unused")
+    public static void move(Coordinates coordinates) {
+        move(coordinates.x(), coordinates.y());
+    }
+
+    /**
+     * Preform a mouse event at the given location
+     *
+     * @param x        x coordinate
+     * @param y        y coordinate
+     * @param consumer event
+     */
+    @SuppressWarnings("unused")
+    public static void performAt(int x, int y, Consumer<Coordinates> consumer) {
+        consumer.accept(calcRealPositionOfWidget(x, y));
+    }
+
     /**
      * Initializes the User32.dll for windows
      */
     private static void initializeUser32dll() {
-        if(!OsUtils.isWindows())
+        if (!OsUtils.isWindows())
             return;
 
         try {

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/MouseUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/MouseUtils.java
@@ -100,10 +100,30 @@ public class MouseUtils {
         );
     }
 
+    /**
+     * Press left mouse key down at the current pixel location.
+     */
+    public static void leftDown() {
+        doNativeMouseAction("left down", true,
+                "xdotool mousedown 1",
+                (i) -> i.mouse_event(MouseEventFlags.LEFTDOWN.getValue(), 0, 0, 0, 0)
+        );
+    }
+
+    /**
+     * Press left mouse key up at the current pixel location.
+     */
+    public static void leftUp() {
+        doNativeMouseAction("left up", true,
+                "xdotool mouseup 1",
+                (i) -> i.mouse_event(MouseEventFlags.LEFTUP.getValue(), 0, 0, 0, 0)
+        );
+    }
 
     /**
      * Perform middle click at the current pixel location.
      */
+    @SuppressWarnings("unused")
     public static void middleClick() {
         doNativeMouseAction("middle click", true,
                 "xdotool click 2",
@@ -111,6 +131,26 @@ public class MouseUtils {
                     i.mouse_event(MouseEventFlags.MIDDLEDOWN.getValue(), 0, 0, 0, 0);
                     i.mouse_event(MouseEventFlags.MIDDLEUP.getValue(), 0, 0, 0, 0);
                 }
+        );
+    }
+
+    /**
+     * Press middle mouse key down at the current pixel location.
+     */
+    public static void middleDown() {
+        doNativeMouseAction("middle down", true,
+                "xdotool mousedown 2",
+                (i) -> i.mouse_event(MouseEventFlags.MIDDLEDOWN.getValue(), 0, 0, 0, 0)
+        );
+    }
+
+    /**
+     * Press middle mouse key up at the current pixel location.
+     */
+    public static void middleUp() {
+        doNativeMouseAction("middle up", true,
+                "xdotool mouseup 2",
+                (i) -> i.mouse_event(MouseEventFlags.MIDDLEUP.getValue(), 0, 0, 0, 0)
         );
     }
 
@@ -124,6 +164,26 @@ public class MouseUtils {
                     i.mouse_event(MouseEventFlags.RIGHTDOWN.getValue(), 0, 0, 0, 0);
                     i.mouse_event(MouseEventFlags.RIGHTUP.getValue(), 0, 0, 0, 0);
                 }
+        );
+    }
+
+    /**
+     * Press right mouse key down at the current pixel location.
+     */
+    public static void rightDown() {
+        doNativeMouseAction("right down", true,
+                "xdotool mousedown 3",
+                (i) -> i.mouse_event(MouseEventFlags.RIGHTDOWN.getValue(), 0, 0, 0, 0)
+        );
+    }
+
+    /**
+     * Press right mouse key up at the current pixel location.
+     */
+    public static void rightUp() {
+        doNativeMouseAction("right up", true,
+                "xdotool mouseup 3",
+                (i) -> i.mouse_event(MouseEventFlags.RIGHTUP.getValue(), 0, 0, 0, 0)
         );
     }
 


### PR DESCRIPTION
The previous implementation #95 will cause the `Attack/Destroy` key (left mouse key) won't break any block requires key pressing.