### PR TITLE
[1.20] Camera look straight up down WIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ This feature adds the following key bindings to control the camera through the k
 10. Right Alt + Look Right Key or Look East Key (default: Keypad 9) = Snaps the camera to the east block.
 11. Right Alt + Look Down Key or Look South Key (default: Keypad 3) = Snaps the camera to the south block.
 12. Right Alt + Look Left Key or Look West Key (default: Keypad 1) = Snaps the camera to the west block.
-13. Center Camera (default: Keypad 5) = Snaps the camera to the closest cardinal direction and centers it.
-14. Left Alt + Center Camera = Snaps the camera to the closest opposite cardinal direction and centers it.
+13. Right Alt + double Look Up Key or Look Straight Up Key (default: Keypad 0): Snaps the camera to the look above head direction.
+14. Right Alt + double Look Down Key (default: O) or Look Straight Down Key (default: Keypad `.` (decimal, dot)): Snaps the camera to the look down at feet direction.
+15. Center Camera (default: Keypad 5) = Snaps the camera to the closest cardinal direction and centers it.
+16. Left Alt + Center Camera = Snaps the camera to the closest opposite cardinal direction and centers it.
 
 **Configuration Options:-**
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -12,6 +12,17 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
     // Remove the next line if you don't want to depend on the API
     modApi "dev.architectury:architectury:${rootProject.architectury_version}"
+
+    // Unit test dependencies
+    testImplementation "org.junit.jupiter:junit-jupiter:5.10.0"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.0"
+    testImplementation "org.assertj:assertj-core:3.24.2"
+    testImplementation "org.mockito:mockito-core:5.4.0"
+    testImplementation "org.mockito:mockito-junit-jupiter:5.4.0"
+}
+
+test {
+    useJUnitPlatform()
 }
 
 publishing {

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/CameraControls.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/CameraControls.java
@@ -244,7 +244,18 @@ public class CameraControls {
                 playerBlockPosition.z + direction.z);
 
         minecraftClient.player.lookAt(EntityAnchorArgumentType.EntityAnchor.FEET, targetBlockPosition);
-        MainClass.speakWithNarrator(new PlayerPositionUtils(minecraftClient).getHorizontalFacingDirectionInCardinal(), true);
+
+        // log and speak new facing direction
+        MainClass.infoLog("Rotating camera to: %s".formatted(direction.name()));
+
+        PlayerPositionUtils pUtil = new PlayerPositionUtils(this.minecraftClient);
+        boolean isRotatingHorizontal = direction.y == 0;
+
+        if (isRotatingHorizontal) {
+            MainClass.speakWithNarrator(pUtil.getHorizontalFacingDirectionInCardinal(), true);
+        } else {
+            MainClass.speakWithNarrator(pUtil.getVerticalFacingDirectionInWords(), true);
+        }
     }
 
     /**

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/CameraControls.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/CameraControls.java
@@ -52,7 +52,7 @@ public class CameraControls {
 
             loadConfigurations();
             boolean wasAnyKeyPressed = keyListener();
-            if(wasAnyKeyPressed) interval.start();
+            if (wasAnyKeyPressed) interval.start();
         } catch (Exception e) {
             MainClass.errorLog("\nError encountered in Camera Controls feature.");
             e.printStackTrace();
@@ -96,6 +96,9 @@ public class CameraControls {
         boolean isSouthKeyPressed = KeyUtils.isAnyPressed(kbh.cameraControlsSouth)
                 || (isDownKeyPressed && isRightAltPressed && !isLeftAltPressed);
         boolean isCenterCameraKeyPressed = KeyUtils.isAnyPressed(kbh.cameraControlsCenterCamera);
+        // TODO Add double click Up/Down, refactor F4 menu
+        boolean isStraightUpKeyPressed = KeyUtils.isAnyPressed(kbh.cameraControlsStraightUp);
+        boolean isStraightDownKeyPressed = KeyUtils.isAnyPressed(kbh.cameraControlsStraightDown);
 
         if (isNorthKeyPressed) {
             lookNorth();
@@ -139,6 +142,16 @@ public class CameraControls {
 
         if (isCenterCameraKeyPressed) {
             centerCamera(isLeftAltPressed);
+            return true;
+        }
+
+        if (isStraightUpKeyPressed) {
+            lookAtRelativeBlock(0, 1, 0);
+            return true;
+        }
+
+        if (isStraightDownKeyPressed) {
+            lookAtRelativeBlock(0, -1, 0);
             return true;
         }
 
@@ -201,69 +214,70 @@ public class CameraControls {
      * Snaps the camera to the north block
      */
     private void lookNorth() {
-        lookAtRelativeBlock(0, -1);
+        lookAtRelativeBlock(0, 0, -1);
     }
 
     /**
      * Snaps the camera to the east block
      */
     private void lookEast() {
-        lookAtRelativeBlock(1, 0);
+        lookAtRelativeBlock(1, 0, 0);
     }
 
     /**
      * Snaps the camera to the west block
      */
     private void lookWest() {
-        lookAtRelativeBlock(-1, 0);
+        lookAtRelativeBlock(-1, 0, 0);
     }
 
     /**
      * Snaps the camera to the south block
      */
     private void lookSouth() {
-        lookAtRelativeBlock(0, 1);
+        lookAtRelativeBlock(0, 0, 1);
     }
 
     /**
      * Snaps the camera to the north-east block
      */
     private void lookNorthEast() {
-        lookAtRelativeBlock(1, -1);
+        lookAtRelativeBlock(1, 0, -1);
     }
 
     /**
      * Snaps the camera to the north-west block
      */
     private void lookNorthWest() {
-        lookAtRelativeBlock(-1, -1);
+        lookAtRelativeBlock(-1, 0, -1);
     }
 
     /**
      * Snaps the camera to the south-east block
      */
     private void lookSouthEast() {
-        lookAtRelativeBlock(1, 1);
+        lookAtRelativeBlock(1, 0, 1);
     }
 
     /**
      * Snaps the camera to the south-west block
      */
     private void lookSouthWest() {
-        lookAtRelativeBlock(-1, 1);
+        lookAtRelativeBlock(-1, 0, 1);
     }
 
     /**
      * Snaps the camera at a block relative to the player's position.
      *
      * @param deltaX The relative X position of the block.
+     * @param deltaY The relative Y position of the block.
      * @param deltaZ The relative Z position of the block.
      */
-    private void lookAtRelativeBlock(int deltaX, int deltaZ) {
+    private void lookAtRelativeBlock(int deltaX, int deltaY, int deltaZ) {
         if (minecraftClient.player == null) return;
 
         Vec3d playerBlockPosition = minecraftClient.player.getPos();
-        Vec3d relativeBlockPosition = new Vec3d(playerBlockPosition.x + deltaX, playerBlockPosition.y + 0, playerBlockPosition.z + deltaZ);
+        Vec3d relativeBlockPosition = new Vec3d(playerBlockPosition.x + deltaX, playerBlockPosition.y + deltaY, playerBlockPosition.z + deltaZ);
 
         minecraftClient.player.lookAt(EntityAnchorArgumentType.EntityAnchor.FEET, relativeBlockPosition);
         MainClass.speakWithNarrator(new PlayerPositionUtils(minecraftClient).getHorizontalFacingDirectionInCardinal(), true);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/narrator_menu/NarratorMenu.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/narrator_menu/NarratorMenu.java
@@ -5,10 +5,7 @@ import com.github.khanshoaib3.minecraft_access.config.ConfigMenu;
 import com.github.khanshoaib3.minecraft_access.features.BiomeIndicator;
 import com.github.khanshoaib3.minecraft_access.features.ReadCrosshair;
 import com.github.khanshoaib3.minecraft_access.screen_reader.ScreenReaderController;
-import com.github.khanshoaib3.minecraft_access.utils.ClientPlayerEntityUtils;
-import com.github.khanshoaib3.minecraft_access.utils.KeyBindingsHandler;
-import com.github.khanshoaib3.minecraft_access.utils.KeyUtils;
-import com.github.khanshoaib3.minecraft_access.utils.PositionUtils;
+import com.github.khanshoaib3.minecraft_access.utils.*;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.MinecraftClient;
@@ -32,6 +29,8 @@ import java.util.stream.Stream;
  */
 public class NarratorMenu {
     private static MinecraftClient minecraftClient;
+    private static final TimeUtils.KeystrokeChecker narratorMenuKeyCondition;
+    private static final TimeUtils.KeystrokeChecker narratorMenuHotKeyCondition;
     private static boolean isMenuKeyPressedPreviousTick = false;
     private static boolean isHotKeyPressedPreviousTick = false;
     private static boolean isHotKeySwitchedPreviousTick = false;
@@ -41,6 +40,11 @@ public class NarratorMenu {
 
     static {
         Arrays.fill(LAST_RUN_HAS_DONE_FLAG, true);
+
+        // config keystroke conditions
+        KeyBindingsHandler kbh = KeyBindingsHandler.getInstance();
+        narratorMenuKeyCondition = new TimeUtils.KeystrokeChecker(() -> KeyUtils.isAnyPressed(kbh.narratorMenuKey));
+        narratorMenuHotKeyCondition = new TimeUtils.KeystrokeChecker(() -> KeyUtils.isAnyPressed(kbh.narratorMenuHotKey));
     }
 
     /**
@@ -149,6 +153,8 @@ public class NarratorMenu {
             }
 
             // update the states for next tick
+            narratorMenuKeyCondition.updateStateForNextTick();
+            narratorMenuHotKeyCondition.updateStateForNextTick();
             isMenuKeyPressedPreviousTick = isNarratorMenuKeyPressed;
             isHotKeyPressedPreviousTick = isNarratorMenuHotKeyPressed;
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/KeyBindingsHandler.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/KeyBindingsHandler.java
@@ -29,6 +29,8 @@ public class KeyBindingsHandler {
     public KeyBinding cameraControlsWest;
     public KeyBinding cameraControlsSouth;
     public KeyBinding cameraControlsCenterCamera;
+    public KeyBinding cameraControlsStraightUp;
+    public KeyBinding cameraControlsStraightDown;
 
     public KeyBinding inventoryControlsGroupKey;
     public KeyBinding inventoryControlsUpKey;
@@ -183,6 +185,8 @@ public class KeyBindingsHandler {
      * 12) Right Alt + Look Left Key or Look West Key (default=keypad 1): Snaps the camera to the west block.<br>
      * 13) Center Camera Key (default=keypad 5): Snaps the camera to the closest cardinal direction and center it.<br>
      * 14) Left Alt + Center Camera Key : Snaps the camera to the closest opposite cardinal direction and center it.<br>
+     * 15) Right Alt + double Look Up Key or Look Straight Up Key (default: Keypad 0): Snaps the camera to the look above head direction.
+     * 16) Right Alt + double Look Down Key or Look Straight Down Key (default: Keypad .): Snaps the camera to the look down at feet direction.
      */
     private void initializeCameraControlsKeybindings() {
         cameraControlsUp = new KeyBinding(
@@ -280,6 +284,22 @@ public class KeyBindingsHandler {
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
         KeyMappingRegistry.register(cameraControlsSouth);
+
+        cameraControlsStraightUp = new KeyBinding(
+                "minecraft_access.keys.camera_controls.straight_up_camera_key_name",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_KP_0,
+                CAMERA_CONTROLS_TRANSLATION_KEY
+        );
+        KeyMappingRegistry.register(cameraControlsStraightUp);
+
+        cameraControlsStraightDown = new KeyBinding(
+                "minecraft_access.keys.camera_controls.straight_down_camera_key_name",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_KP_DECIMAL,
+                CAMERA_CONTROLS_TRANSLATION_KEY
+        );
+        KeyMappingRegistry.register(cameraControlsStraightDown);
 
         cameraControlsCenterCamera = new KeyBinding(
                 "minecraft_access.keys.camera_controls.center_camera_key_name",

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/TimeUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/TimeUtils.java
@@ -1,6 +1,11 @@
 package com.github.khanshoaib3.minecraft_access.utils;
 
+import java.util.function.BooleanSupplier;
+
 public class TimeUtils {
+    /**
+     * An auto-refresh countdown timer for controlling interval execution of features.
+     */
     public static class Interval {
         private long lastRunTime;
         private final long delay;
@@ -68,6 +73,52 @@ public class TimeUtils {
         public void start() {
             this.isRunning = true;
             reset();
+        }
+    }
+
+    /**
+     * A state machine that helps with complex keystroke condition checking,
+     * such as "when-the-key-is-released", "only-trigger-once-before-release-key", "double-strike-within-interval".
+     */
+    public static class KeystrokeChecker {
+        /**
+         * Save the state of keystroke at the previous tick.
+         */
+        private boolean hasKeyPressed = false;
+        /**
+         * Expression that checking if the key (combination) is pressed now.
+         */
+        private final BooleanSupplier condition;
+
+        /**
+         * @param condition Expression that checking if the key (combination) is pressed now.
+         */
+        public KeystrokeChecker(BooleanSupplier condition) {
+            this.condition = condition;
+        }
+
+        /**
+         * Update state according to the condition result.
+         * Invoke this method at the end of feature logic.
+         */
+        public void updateStateForNextTick() {
+            hasKeyPressed = isKeyPressing();
+        }
+
+        public boolean isKeyPressing() {
+            return condition.getAsBoolean();
+        }
+
+        public boolean hasKeyPressedPreviousTick() {
+            return hasKeyPressed;
+        }
+
+        public boolean isKeyReleased() {
+            return !isKeyPressing() && hasKeyPressedPreviousTick();
+        }
+
+        public boolean isKeyPressed() {
+            return isKeyPressing() && !hasKeyPressedPreviousTick();
         }
     }
 }

--- a/common/src/test/java/com/github/khanshoaib3/minecraft_access/utils/TimeUtilsTest.java
+++ b/common/src/test/java/com/github/khanshoaib3/minecraft_access/utils/TimeUtilsTest.java
@@ -1,0 +1,113 @@
+package com.github.khanshoaib3.minecraft_access.utils;
+
+import org.jetbrains.annotations.TestOnly;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.BooleanSupplier;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TimeUtilsTest {
+
+    @Nested
+    class KeystrokeCheckerTest {
+        /**
+         * Combining a changeable boolean variable with supplier.
+         */
+        @TestOnly
+        static class MockKeystroke {
+            Boolean pressed;
+            BooleanSupplier supplier;
+
+            public void revertKeystrokeResult() {
+                this.pressed = !this.pressed;
+            }
+
+            public MockKeystroke(boolean initPressed) {
+                this.pressed = initPressed;
+                this.supplier = () -> this.pressed;
+            }
+        }
+
+        @Test
+        void testMockKeystrokeWorks() {
+            var m = new MockKeystroke(true);
+            var k = new TimeUtils.KeystrokeChecker(m.supplier);
+            assertThat(k.isKeyPressing()).isEqualTo(true);
+            m.revertKeystrokeResult();
+            assertThat(k.isKeyPressing()).isEqualTo(false);
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideKeystrokeCheckerTestCases")
+        void testIsKeyPressing(MockKeystroke keystroke, boolean expected) {
+            TimeUtils.KeystrokeChecker checker = new TimeUtils.KeystrokeChecker(keystroke.supplier);
+            assertThat(checker.isKeyPressing()).isEqualTo(expected);
+            keystroke.revertKeystrokeResult();
+            assertThat(checker.isKeyPressing())
+                    .as("keystroke condition should be reverted")
+                    .isEqualTo(!expected);
+        }
+
+        static Stream<Arguments> provideKeystrokeCheckerTestCases() {
+            return Stream.of(
+                    Arguments.of(new MockKeystroke(true), true),
+                    Arguments.of(new MockKeystroke(false), false)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideKeystrokeCheckerTestCases")
+        void testHasKeyPressed(MockKeystroke keyStroke, boolean expected) {
+            TimeUtils.KeystrokeChecker checker = new TimeUtils.KeystrokeChecker(keyStroke.supplier);
+
+            // tick 0
+            checker.updateStateForNextTick();
+
+            // tick 1
+            assertThat(checker.hasKeyPressedPreviousTick()).isEqualTo(expected);
+            keyStroke.revertKeystrokeResult();
+            checker.updateStateForNextTick();
+
+            // tick 2
+            assertThat(checker.hasKeyPressedPreviousTick())
+                    .as("keystroke condition should be reverted")
+                    .isEqualTo(!expected);
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideKeystrokeCheckerTestCases")
+        void testIsKeyReleased(MockKeystroke keyStroke, boolean expected) {
+            TimeUtils.KeystrokeChecker checker = new TimeUtils.KeystrokeChecker(keyStroke.supplier);
+
+            // tick 0
+            checker.updateStateForNextTick();
+
+            // tick 1
+            keyStroke.revertKeystrokeResult();
+            assertThat(checker.isKeyReleased())
+                    .as("pressed key should be released now, vice versa")
+                    .isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideKeystrokeCheckerTestCases")
+        void testIsKeyPressed(MockKeystroke keyStroke, boolean expected) {
+            TimeUtils.KeystrokeChecker checker = new TimeUtils.KeystrokeChecker(keyStroke.supplier);
+
+            // tick 0
+            checker.updateStateForNextTick();
+
+            // tick 1
+            keyStroke.revertKeystrokeResult();
+            assertThat(checker.isKeyPressed())
+                    .as("released key should be pressed now, vice versa")
+                    .isEqualTo(!expected);
+        }
+    }
+}


### PR DESCRIPTION
I've implemented #123, and refactored other related logic as well.
But all the changes combined amount to over 900 lines of code.
So I'll separate this feature branch into multiple small (still not so small) PRs.
Planning on release a new version after these PRs are merged.

In this PR I:

* Implement single-key version of feature for #123
* Add two new key bindings `Look Straight Up Key`, `Look Straight Down Key` : https://github.com/khanshoaib3/minecraft-access-i18n/pull/17
* Simplify logic of `CameraControls` with new enums, for readability.
* Add a new `KeystrokeChecker` (renamed later as `Keystroke`) for reusable key pressing condition checking.
* Add unit test dependencies for writing tests for `KeystrokeChecker`.