### PR TITLE
Make change log submitting fragmented

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,10 @@
 ## Pull Request Checklist
 
-(Use `~~ -[ ] ... ~~` markdown deletion syntax to cross out unrelated entries.)
+[//]: # (Use `~~ -[ ] ... ~~` markdown deletion syntax to cross out unrelated entries)
 
-- [ ] A new entry is added in `CHANGELOG.md` that describes what is changed.
+- [ ] A new fragment is added in `./doc/news` that describes what is new (refer to issue #174).
 - [ ] The unit test suite passes at the latest commit of this PR branch.
 
 ## Describe what you have changed in this PR
 
+[//]: # (See commit messages.)

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,3 @@
-Please read [this issue for guide for modifying this document](https://github.com/khanshoaib3/minecraft-access/pull/155)
-
 Release v1.3.0 (2023-09)
 ---------------------------
 
@@ -16,7 +14,7 @@ Release v1.3.0 (2023-09)
 
 ### Refactoring, Documentation and Chores
 
-* Rewrite big README into [manual structure](https://github.com/khanshoaib3/minecraft-access/blob/1.20/README.md) for better readability.
+* Rewrite big README into [manual structure](https://github.com/khanshoaib3/minecraft-access/blob/1.20/README.md) for better readability. [#134](https://github.com/khanshoaib3/minecraft-access/issues/134)
 
 Release v1.2.2 (2023-09-12)
 ---------------------------

--- a/doc/news/CHANGE_FRAGMENT_TEMPLATE.md
+++ b/doc/news/CHANGE_FRAGMENT_TEMPLATE.md
@@ -1,0 +1,9 @@
+### New Features
+
+### Feature Changes
+
+### Bug Fixes
+
+### Dependencies Changes
+
+### Refactoring, Documentation and Chores

--- a/doc/news/change_log_fragment.md
+++ b/doc/news/change_log_fragment.md
@@ -1,0 +1,11 @@
+### New Features
+
+### Feature Changes
+
+### Bug Fixes
+
+### Dependencies Changes
+
+### Refactoring, Documentation and Chores
+
+* Now the change log should be added as a small independent markdown file (fragment) under `./doc/news`.


### PR DESCRIPTION
## Pull Request Checklist

(Use `~~ -[ ] ... ~~` markdown deletion syntax to cross out unrelated entries.)

- [x] A new entry is added in `CHANGELOG.md` that describes what is changed.
- [x] The unit test suite passes at the latest commit of this PR branch.

## Describe what you have changed in this PR

Single `CHANGELOG.md` file can unintentionally create more merge conflicts, since all PRs will modify this file.
Basing on #155, further breaking down the change log into small separate files can solve this problem.

That's [how the automatic tool does](https://github.com/twisted/towncrier), looks like we learned a lesson in practice.
We can't directly use this tool (yet) since our PR doesn't strictly follow the ticket (one PR <--> one issue) mechanism, and we doesn't have a automated release pipeline.