### PR TITLE
[1.16.1] Update Minecraft Wiki links to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ redstone signal or when a door is open and other similar cases.
    For example, the White Bed is written in "white_bed" and pronounced as "white underscore bed".
    There are lots of exceptions, the "Smooth Quartz Block" is written in "smooth_quartz", the "Block of Diamond" is written in "diamond_block",
    so please check the correct values in this wiki link:
-   https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+   https://minecraft.wiki/w/Java_Edition_data_values#Blocks
 
 ## Position Narrator
 
@@ -308,7 +308,7 @@ Check the surrounding height difference and warn the user with a drop sound effe
 
 ## Book Editing
 
-Press Use key while holding a [Book and Quill](https://minecraft.fandom.com/wiki/Book_and_Quill) item to open the book editing screen.
+Press Use key while holding a [Book and Quill](https://minecraft.wiki/w/Book_and_Quill) item to open the book editing screen.
 Press Tab key to select buttons, while button is focused, press Space key or Left Mouse key to click it (space can be inputted as text when no button is focused).
 Press Page Up and Page Down Key to switch between pages.
 Press "Done" button to save your unfinished work and quit editing screen.

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/KeyUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/KeyUtils.java
@@ -36,7 +36,7 @@ public class KeyUtils {
 
     /**
      * This works even if the keybinding is duplicate i.e. another keybinding has the same key bound to it.<br>
-     * <a href="https://minecraft.fandom.com/wiki/Key_codes">Vanilla Keybinding instance translation keys in Minecraft</a><br>
+     * <a href="https://minecraft.wiki/w/Key_codes">Vanilla Keybinding instance translation keys in Minecraft</a><br>
      * Get these instances via InputUtil.fromTranslationKey({key})
      */
     public static boolean isAnyPressed(KeyBinding... keyBindings) {

--- a/doc/SET_UP_ON_WINDOWS.md
+++ b/doc/SET_UP_ON_WINDOWS.md
@@ -284,7 +284,7 @@ For this type of error, there is a simple, common, cumbersome, no-better-choice 
 ## Some Helpful Links
 
 * [The manual of this mod](https://github.com/khanshoaib3/minecraft-access) - Check what features this mod provides.
-* [Minecraft Wiki](https://minecraft.fandom.com/wiki/Minecraft_Wiki) - Has details and guides on everything about Minecraft.
+* [Minecraft Wiki](https://minecraft.wiki/w/Minecraft_Wiki) - Has details and guides on everything about Minecraft.
 * [Minecraft Survival Guide (Season 3)](https://www.youtube.com/watch?v=VfpHTJsn9I4&list=PLgENJ0iY3XBjmydGuzYTtDwfxuR6lN8KC) - A great series by Pixlriffs, highly recommend for beginners.
 * [Playability Discord server](https://discord.gg/yQjjsDqWQX) - Again, you can join our Discord server if you need help in setting up the mod or any issue related to Minecraft Java.
 * [Twitter](https://twitter.com/shoaib_mk0) - You can follow the developer on Twitter to get notification when a new update drops.


### PR DESCRIPTION
## Pull Request Checklist

[//]: # (Use `~~ -[ ] ... ~~` markdown deletion syntax to cross out unrelated entries)

~~A new fragment is added in `./doc/news` that describes what is new (refer to issue #174).~~
~~The unit test suite passes at the latest commit of this PR branch.~~

## Describe what you have changed in this PR
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. This PR updates all URLs accordingly.
Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom.

[//]: # (See commit messages.)