### PR TITLE
(1.20) Update Minecraft Wiki links to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This mod supports:
 
 ## Useful Links
 
-* [Minecraft Wiki](https://minecraft.fandom.com/wiki/Minecraft_Wiki) - Has details and guides on everything about Minecraft.
+* [Minecraft Wiki](https://minecraft.wiki/w/Minecraft_Wiki) - Has details and guides on everything about Minecraft.
 * [Minecraft Survival Guide (Season 3)](https://www.youtube.com/watch?v=VfpHTJsn9I4&list=PLgENJ0iY3XBjmydGuzYTtDwfxuR6lN8KC) - A great series by Pixlriffs, highly recommend for beginners.
 * [Playability Discord server](https://discord.gg/yQjjsDqWQX) - Join our Discord server if you want to chat with other this mod's users and developers.
 * [Twitter](https://twitter.com/shoaib_mk0) - You can follow the developer on Twitter to get notification when a new update drops.

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
@@ -397,7 +397,7 @@ public class ReadCrosshair {
                 .collect(Collectors.toList());
 
         // Unconnected redstone dust now has all direction block states set to "side" since 20w18a (before 1.16)
-        // https://minecraft.fandom.com/wiki/Redstone_Dust
+        // https://minecraft.wiki/w/Redstone_Dust
         // So here is an additional check to see if the redstone wire is really connected to all directions
         if (connectedDirections.size() == 4) {
             Optional<Boolean> result = WorldUtils.checkAnyOfSurroundingBlocks(pos, THREE_SAMPLE_POSITIONS, IS_REDSTONE_WIRE);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/system/KeyUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/system/KeyUtils.java
@@ -36,7 +36,7 @@ public class KeyUtils {
 
     /**
      * This works even if the keybinding is duplicate i.e. another keybinding has the same key bound to it.<br>
-     * <a href="https://minecraft.fandom.com/wiki/Key_codes">Vanilla Keybinding instance translation keys in Minecraft</a><br>
+     * <a href="https://minecraft.wiki/w/Key_codes">Vanilla Keybinding instance translation keys in Minecraft</a><br>
      * Get these instances via InputUtil.fromTranslationKey({key})
      */
     public static boolean isAnyPressed(KeyBinding... keyBindings) {

--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -78,7 +78,7 @@ See also: [Feature Description](/doc/FEATURES.md#read-crosshair)
 The `Targets` config can only be configured in `config.json` file.
 Values are written in Minecraft resource location format, the so-called "snake_case" (consists of lowercase letters with underscores).
 For example, the White Bed is written in "white_bed".
-There are lots of exceptions, the "Smooth Quartz Block" is written in "smooth_quartz", the "Block of Diamond" is written in "diamond_block", so please check the correct values in [this wiki link](https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks) (expand to show the list by clicking "Blocks[show]" then "Item form's ID[show]").
+There are lots of exceptions, the "Smooth Quartz Block" is written in "smooth_quartz", the "Block of Diamond" is written in "diamond_block", so please check the correct values in [this wiki link](https://minecraft.wiki/w/Java_Edition_data_values#Blocks) (expand to show the list by clicking "Blocks[show]" then "Item form's ID[show]").
 
 See also: [Feature Description](/doc/FEATURES.md#partial-speaking)
 
@@ -92,7 +92,7 @@ See also: [Feature Description](/doc/FEATURES.md#partial-speaking)
 | Row and Column Format in Crafting Input Slots                                             | "%dx%d"       | The speaking format of row and column prefix, two "%d" are representing the position of row and column |
 | Delay (in milliseconds)                                                                   | 250           | Cooldown between two feature executions                                                                |
 
-Most recipes [require](https://minecraft.fandom.com/wiki/Crafting) their ingredients to be arranged in a specific way on the crafting grid (a.k.a. our crafting input group).
+Most recipes [require](https://minecraft.wiki/w/Crafting) their ingredients to be arranged in a specific way on the crafting grid (a.k.a. our crafting input group).
 That's how `Row and Column Format in Crafting Input Slots` config can help you, you'll hear something like "1x2 Empty Slot" which represent you're locating at row one and column two slot inside the crafting input group, and it contains nothing.
 
 See also: [Feature Description](/doc/FEATURES.md#inventory-controls), [Keybindings](/doc/KEYBINDINGS.md#inventory-controls)
@@ -132,7 +132,7 @@ See also: [Feature Description](/doc/FEATURES.md#point-of-interest), [Keybinding
 | Play Sound                              | true          | Play a sound cue at positions of detected entities                                                    |
 | Speak Relative Distance to Entity/Block | false         | Speak relative distance to the target when locking on                                                 |
 | Play Unlocking Sound                    | true          | Play a sound cue on unlock                                                                            |
-| Auto Lock on to Eye of Ender when Used  | true          | Automatically lock on to the [Eye of Ender](https://minecraft.fandom.com/wiki/Eye_of_Ender) when used |
+| Auto Lock on to Eye of Ender when Used  | true          | Automatically lock on to the [Eye of Ender](https://minecraft.wiki/w/Eye_of_Ender) when used |
 | Delay (in milliseconds)                 | 100           | Cooldown between two feature executions                                                               |
 
 ### Entities/Blocks Marking
@@ -211,7 +211,7 @@ See also: [Feature Description](/doc/FEATURES.md#narrator-menu), [Keybindings](/
 | Enable Biome Indicator                 | true          | Whether to enable [`Biome Indicator`](/doc/FEATURES.md#biome-indicator) feature                                                                           |
 | Enable XP Indicator                    | true          | Whether to enable [`XP Indicator`](/doc/FEATURES.md#xp-indicator) feature                                                                                 |
 | Use 12 Hour Time Format                | false         | Whether to use 12 hour time format when speaking the time                                                                                                 | 
-| Speak Action Bar Updates               | true          | Whether to speak the messages updated in [action bar](https://minecraft.fandom.com/wiki/Commands/title), useful when you're in modded multiplayer servers |
+| Speak Action Bar Updates               | true          | Whether to speak the messages updated in [action bar](https://minecraft.wiki/w/Commands/title), useful when you're in modded multiplayer servers |
 | Speak Harvest Of Fishing               | true          | Whether to speak the harvest of fishing                                                                                                                   |
 | Enable Menu Fix                        | true          | Whether to reset the cursor position when opening a menu (to prevent speak out unnecessary content)                                                       |
 | Debug Mode                             | true          | Developer config, whether to print debug messages into log                                                                                                |

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -24,7 +24,7 @@ First, this mod does not achieve 100% accessibility.
 For example, you'll find rowing the boat is difficult (since the relevant feature haven't been implemented yet), you can't directly recognize blocks that are placed together as a structure (since you can't see the entire appearance of a group of blocks, and there's very little this mod can do about that).
 We're gradually adding new features, but I'm pessimistic that the Minecraft is too complex to ever achieve 100% accessibility.
 
-Second, the Minecraft, despite the fact that it has a large number of players, is not easy to get started with. You'll need to learn many new concepts and knowledge to play it. You can learn how to play this game by listening the playing video (I recommend [Pixlriffs's Minecraft Survival Guide](https://www.youtube.com/watch?v=VfpHTJsn9I4&list=PLgENJ0iY3XBjmydGuzYTtDwfxuR6lN8KC)), reading [the wiki](https://minecraft.fandom.com/wiki/Minecraft_Wiki), or find someone skilled enough to teach you.
+Second, the Minecraft, despite the fact that it has a large number of players, is not easy to get started with. You'll need to learn many new concepts and knowledge to play it. You can learn how to play this game by listening the playing video (I recommend [Pixlriffs's Minecraft Survival Guide](https://www.youtube.com/watch?v=VfpHTJsn9I4&list=PLgENJ0iY3XBjmydGuzYTtDwfxuR6lN8KC)), reading [the wiki](https://minecraft.wiki/w/Minecraft_Wiki), or find someone skilled enough to teach you.
 
 So if you haven't bought the game yet and don't know much about Minecraft, think again before paying.
 
@@ -38,7 +38,7 @@ We stick to the pure client-side strategy for now, since you need to install a s
 
 Sorry for the inconvenience. Here are some self-help materials to help you.
 If you have any question about installing, please read the [set-up guide](/doc/SET_UP.md). 
-If you have any question about original game functions, please search on the [wiki](https://minecraft.fandom.com/wiki/Special:Search?scope=internal) or just google it.
+If you have any question about original game functions, please search on the [wiki](https://minecraft.wiki/w/Special:Search?scope=internal) or just google it.
 If you have any question about this mod, please read the [manual](/README.md).
 
 ## Why this mod is updated slowly / the feature I asked was not released in the new version?

--- a/doc/FEATURES.md
+++ b/doc/FEATURES.md
@@ -1,7 +1,7 @@
 # Minecraft Access Features
 
 This page contains details of all the features that are currently in the mod.
-If you have any question about original game functions, please search on the [wiki](https://minecraft.fandom.com/wiki/Special:Search?scope=internal) first before asking for help.
+If you have any question about original game functions, please search on the [wiki](https://minecraft.wiki/w/Special:Search?scope=internal) first before asking for help.
 If you have any suggestion on improvements existing features or about a new feature, you can [join the discord server](https://discord.gg/yQjjsDqWQX) or [post an issue](https://github.com/khanshoaib3/minecraft-access/issues).
 
 ## Table Of Contents
@@ -102,13 +102,13 @@ By the same token, entities are movable, so scanning and locking onto them helps
 
 | Sound Cue                                                                                             | Description                                                                                                                                                                                             |
 |-------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Functional blocks without screens (like door, ladder)                                                 | ["Bit" (Square wave) of Note Block](https://minecraft.fandom.com/wiki/Note_Block#Notes), a beeping electronic sound                                                                                     |
-| Functional blocks that have screens (like crafting table)                                             | [Banjo of Note Block](https://minecraft.fandom.com/wiki/Note_Block#Notes), a string instrument sound                                                                                                    |
-| [Ore blocks](https://minecraft.fandom.com/wiki/Ore)                                                   | [Item plops](https://minecraft.fandom.com/wiki/Item_(entity)#Sounds), bubbling sound, like the sound of pulling out a toilet plunger                                                                    |
-| [Item (entity)](https://minecraft.fandom.com/wiki/Item_(entity))                                      | [Pressure Plate clicks](https://minecraft.fandom.com/wiki/Pressure_Plate#Unique), crisp clacking sound, like sound of a lighter, or clicking on buttons                                                 |
-| [Passive mobs, Neutral mobs or Players](https://minecraft.fandom.com/wiki/Mob?so=search#Passive_mobs) | [Bells (Glockenspiel) of Note Block](https://minecraft.fandom.com/wiki/Note_Block#Notes), with the lowest pitch, like the sound of a little bell                                                        |
-| [Hostile mobs](https://minecraft.fandom.com/wiki/Mob?so=search#Hostile_mobs)                          | [Bells (Glockenspiel) of Note Block](https://minecraft.fandom.com/wiki/Note_Block#Notes) again, with the highest pitch, brief and sharp, like the sound of a time bomb, and you can hear their low roar |
-| Unlocking                                                                                             | [Bass Drum (Kick) of Note Block](https://minecraft.fandom.com/wiki/Note_Block#Notes) with the highest pitch, but it's still pretty low                                                                  |
+| Functional blocks without screens (like door, ladder)                                                 | ["Bit" (Square wave) of Note Block](https://minecraft.wiki/w/Note_Block#Notes), a beeping electronic sound                                                                                     |
+| Functional blocks that have screens (like crafting table)                                             | [Banjo of Note Block](https://minecraft.wiki/w/Note_Block#Notes), a string instrument sound                                                                                                    |
+| [Ore blocks](https://minecraft.wiki/w/Ore)                                                   | [Item plops](https://minecraft.wiki/w/Item_(entity)#Sounds), bubbling sound, like the sound of pulling out a toilet plunger                                                                    |
+| [Item (entity)](https://minecraft.wiki/w/Item_(entity))                                      | [Pressure Plate clicks](https://minecraft.wiki/w/Pressure_Plate#Unique), crisp clacking sound, like sound of a lighter, or clicking on buttons                                                 |
+| [Passive mobs, Neutral mobs or Players](https://minecraft.wiki/w/Mob?so=search#Passive_mobs) | [Bells (Glockenspiel) of Note Block](https://minecraft.wiki/w/Note_Block#Notes), with the lowest pitch, like the sound of a little bell                                                        |
+| [Hostile mobs](https://minecraft.wiki/w/Mob?so=search#Hostile_mobs)                          | [Bells (Glockenspiel) of Note Block](https://minecraft.wiki/w/Note_Block#Notes) again, with the highest pitch, brief and sharp, like the sound of a time bomb, and you can hear their low roar |
+| Unlocking                                                                                             | [Bass Drum (Kick) of Note Block](https://minecraft.wiki/w/Note_Block#Notes) with the highest pitch, but it's still pretty low                                                                  |
 
 See also: [Configuration](/doc/CONFIG.md#point-of-interest), [Keybindings](/doc/KEYBINDINGS.md#point-of-interest)
 
@@ -134,7 +134,7 @@ It will play a sound effect at every location meets the set threshold, the loude
 
 | Sound Cue                   | Description                                                                                                                        |
 |-----------------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| Position with high drop-off | [Breaking the Anvil](https://minecraft.fandom.com/wiki/Anvil#Generic), same sound as destroying blocks, like the sound of footstep |
+| Position with high drop-off | [Breaking the Anvil](https://minecraft.wiki/w/Anvil#Generic), same sound as destroying blocks, like the sound of footstep |
 
 See also: [Configuration](/doc/CONFIG.md#fall-detector)
 
@@ -147,12 +147,12 @@ This menu integrates a number of helper functions, and you can execute them by o
 |---------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 1. Block and fluid target information | Speak the name and information of the targeted block, the range (20 blocks) is much more than the `Read Crosshair` triggering distance (6 blocks).                                                             |
 | 2. Block and fluid target position    | Speak the x y z position of the targeted block                                                                                                                                                                 |
-| 3. Light level                        | Speak the [light](https://minecraft.fandom.com/wiki/Light) level of the player's position                                                                                                                      |
-| 4. Find Closest Water Source          | Find the closest [water](https://minecraft.fandom.com/wiki/Water) source block in the set range, play a [Item plops](https://minecraft.fandom.com/wiki/Item_(entity)#Sounds) bubbling sound at target position |
-| 5. Find Closest Lava Source           | Find the closest [lava](https://minecraft.fandom.com/wiki/Lava) source block in the set range,  play a [Item plops](https://minecraft.fandom.com/wiki/Item_(entity)#Sounds) bubbling sound at target position  |
-| 6. Biome                              | Speak the name of [biome](https://minecraft.fandom.com/wiki/Biome) the player is currently in                                                                                                                  |
-| 7. Time of Day                        | Speak current time of the in-game [Daylight Cycle](https://minecraft.fandom.com/wiki/Daylight_cycle)                                                                                                           |
-| 8. XP                                 | Speak the player's current [experience](https://minecraft.fandom.com/wiki/Experience) level and progress                                                                                                       |
+| 3. Light level                        | Speak the [light](https://minecraft.wiki/w/Light) level of the player's position                                                                                                                      |
+| 4. Find Closest Water Source          | Find the closest [water](https://minecraft.wiki/w/Water) source block in the set range, play a [Item plops](https://minecraft.wiki/w/Item_(entity)#Sounds) bubbling sound at target position |
+| 5. Find Closest Lava Source           | Find the closest [lava](https://minecraft.wiki/w/Lava) source block in the set range,  play a [Item plops](https://minecraft.wiki/w/Item_(entity)#Sounds) bubbling sound at target position  |
+| 6. Biome                              | Speak the name of [biome](https://minecraft.wiki/w/Biome) the player is currently in                                                                                                                  |
+| 7. Time of Day                        | Speak current time of the in-game [Daylight Cycle](https://minecraft.wiki/w/Daylight_cycle)                                                                                                           |
+| 8. XP                                 | Speak the player's current [experience](https://minecraft.wiki/w/Experience) level and progress                                                                                                       |
 | 9. Refresh screen Reader              | Refresh the screen Reader                                                                                                                                                                                      |
 | 0. Open Config Menu                   | Opens the Config Menu which can be used to change the configs of this mod that take effect immediately                                                                                                         |
 
@@ -164,7 +164,7 @@ Some features that help you understand the status of the character you control.
 
 ### Position Narrator
 
-Minecraft has a built-in [absolute coordinate system](https://minecraft.fandom.com/wiki/Coordinates), x-axis for the longitude, z for the latitude, and y for the elevation. This feature provides keystrokes to read out coordinates.
+Minecraft has a built-in [absolute coordinate system](https://minecraft.wiki/w/Coordinates), x-axis for the longitude, z for the latitude, and y for the elevation. This feature provides keystrokes to read out coordinates.
 
 See also: [Configuration](/doc/CONFIG.md#position-narrator), [Keybindings](/doc/KEYBINDINGS.md#position-narrator)
 
@@ -176,20 +176,20 @@ See also: [Configuration](/doc/CONFIG.md#health-n-hunger), [Keybindings](/doc/KE
 
 ### Player Warnings
 
-This feature warns you when your [health](https://minecraft.fandom.com/wiki/Health), [hunger](https://minecraft.fandom.com/wiki/Hunger) and [air](https://minecraft.fandom.com/wiki/Damage#Drowning) (when you're submerged in water) below the set thresholds.
+This feature warns you when your [health](https://minecraft.wiki/w/Health), [hunger](https://minecraft.wiki/w/Hunger) and [air](https://minecraft.wiki/w/Damage#Drowning) (when you're submerged in water) below the set thresholds.
 You'll hear something like "Warning, Health is {current health}".
 If you enable the `Play Sound` config, you'll also hear a sound cue along with the warning words.
-You may want to learn about [the various damage types](https://minecraft.fandom.com/wiki/Damage) in the game.
+You may want to learn about [the various damage types](https://minecraft.wiki/w/Damage) in the game.
 
 | Sound Cue                  | Description                                                                           |
 |----------------------------|---------------------------------------------------------------------------------------|
-| Status reach the threshold | [Anvil landing](https://minecraft.fandom.com/wiki/Anvil#Unique), crisp metallic sound |
+| Status reach the threshold | [Anvil landing](https://minecraft.wiki/w/Anvil#Unique), crisp metallic sound |
 
 See also: [Configuration](/doc/CONFIG.md#player-warnings)
 
 ## Book Editing
 
-The [Book Editing Screen](https://minecraft.fandom.com/wiki/Book_and_Quill#Writing) is special in that it has nothing to do with item management and has no slot groups.
+The [Book Editing Screen](https://minecraft.wiki/w/Book_and_Quill#Writing) is special in that it has nothing to do with item management and has no slot groups.
 We've added some not re-mappable keys and narration cues to make it 100% accessible.
 This section as a brief guide on how to use this screen, listing the keys corresponding to the functions.
 
@@ -204,15 +204,15 @@ See also: [Configuration](/doc/CONFIG.md#other-configurations)
 ### Speak Held Item
 
 When you switch held items, speak the name and number of items in your hand (main hand only).
-The item [durability](https://minecraft.fandom.com/wiki/Durability) information is included.
+The item [durability](https://minecraft.wiki/w/Durability) information is included.
 
 ### Biome Indicator
 
-Speak the name of the [biome](https://minecraft.fandom.com/wiki/Biome) when you're entering one.
+Speak the name of the [biome](https://minecraft.wiki/w/Biome) when you're entering one.
 
 ### XP Indicator
 
-Speak when your [experience](https://minecraft.fandom.com/wiki/Experience) level is increased or decreased.
+Speak when your [experience](https://minecraft.wiki/w/Experience) level is increased or decreased.
 
 ### Speak Harvest Of Fishing
 
@@ -220,9 +220,9 @@ In fact this feature will speak the items you pick up while you're holding the r
 
 ### Speak Chat Messages and Action Bar Updates
 
-Speak [chat](https://minecraft.fandom.com/wiki/Chat) messages, so you won't miss your friends' conversation.
+Speak [chat](https://minecraft.wiki/w/Chat) messages, so you won't miss your friends' conversation.
 If you feel that too many chat messages are making you feel noisy, you can turn off showing chat messages in the original `Chat Settings...` options.
-Messages updated by the [action bar](https://minecraft.fandom.com/wiki/Commands/title) are common in modded multiplayer servers, usually they are used as announcements.
+Messages updated by the [action bar](https://minecraft.wiki/w/Commands/title) are common in modded multiplayer servers, usually they are used as announcements.
 
 ## Other Pages
 

--- a/doc/KEYBINDINGS.md
+++ b/doc/KEYBINDINGS.md
@@ -7,7 +7,7 @@ You can change these keybindings in the settings (open `Options...` then `Contro
 You may find that some features have duplicate keys, such as I, J, K, L as the arrow keys in various features.
 It's ok since the same key takes effect in different interfaces for different functions.
 
-You may want to take a look at [all the original controls](https://minecraft.fandom.com/wiki/Controls#Java_Edition) as well.
+You may want to take a look at [all the original controls](https://minecraft.wiki/w/Controls#Java_Edition) as well.
 
 ## Table Of Contents
 
@@ -90,7 +90,7 @@ See also: [Feature Description](/doc/FEATURES.md#mouse-simulation), [Configurati
 
 `Switch Tab Key`, `Toggle Craftable Key`, `T` key and `Enter` key only works when there is a corresponding component in the opened screen.
 Recipe Book page turning only works when "Recipe Book Group" is selected.
-Search on the [wiki](https://minecraft.fandom.com/wiki/Special:Search?scope=internal) for the description of screens if you're not familiar with them.
+Search on the [wiki](https://minecraft.wiki/w/Special:Search?scope=internal) for the description of screens if you're not familiar with them.
 
 See also: [Feature Description](/doc/FEATURES.md#inventory-controls), [Configuration](/doc/CONFIG.md#inventory-controls)
 
@@ -148,7 +148,7 @@ See also: [Feature Description](/doc/FEATURES.md#narrator-menu), [Configuration]
 
 | Single Key                                       | Default Keybinding | Description                                                                                                          |
 |--------------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------|
-| `Use Item/Place Block` (the original keybinding) | right mouse key    | Open the book editing screen while holding a [Book and Quill](https://minecraft.fandom.com/wiki/Book_and_Quill) item |
+| `Use Item/Place Block` (the original keybinding) | right mouse key    | Open the book editing screen while holding a [Book and Quill](https://minecraft.wiki/w/Book_and_Quill) item |
 | Tab                                              | not re-mappable    | Select buttons                                                                                                       |
 | Space                                            | not re-mappable    | Click selected button                                                                                                |
 | `Attack/Destroy` (the original keybinding)       | left mouse key     | Same as `Space` key, click selected button                                                                           |

--- a/doc/SET_UP_ON_WINDOWS.md
+++ b/doc/SET_UP_ON_WINDOWS.md
@@ -293,7 +293,7 @@ For this type of error, there is a simple, common, cumbersome, no-better-choice 
 ## Some Helpful Links
 
 * [The manual of this mod](https://github.com/khanshoaib3/minecraft-access) - Check what features this mod provides.
-* [Minecraft Wiki](https://minecraft.fandom.com/wiki/Minecraft_Wiki) - Has details and guides on everything about Minecraft.
+* [Minecraft Wiki](https://minecraft.wiki/w/Minecraft_Wiki) - Has details and guides on everything about Minecraft.
 * [Minecraft Survival Guide (Season 3)](https://www.youtube.com/watch?v=VfpHTJsn9I4&list=PLgENJ0iY3XBjmydGuzYTtDwfxuR6lN8KC) - A great series by Pixlriffs, highly recommend for beginners.
 * [Playability Discord server](https://discord.gg/yQjjsDqWQX) - Again, you can join our Discord server if you need help in setting up the mod or any issue related to Minecraft Java.
 * [Twitter](https://twitter.com/shoaib_mk0) - You can follow the developer on Twitter to get notification when a new update drops.


### PR DESCRIPTION
## Pull Request Checklist

[//]: # (Use `~~ -[ ] ... ~~` markdown deletion syntax to cross out unrelated entries)

~~A new fragment is added in `./doc/news` that describes what is new (refer to issue #174).~~
~~The unit test suite passes at the latest commit of this PR branch.~~

## Describe what you have changed in this PR
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. This PR updates all URLs accordingly.
Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. 

[//]: # (See commit messages.)