### PR TITLE
Fix animated button crush (in Inventory Screen recipe book speaking)

### DIFF
--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/inventory_controls/SlotItem.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/inventory_controls/SlotItem.java
@@ -81,7 +81,6 @@ public class SlotItem {
         }
 
         if (MinecraftClient.getInstance().currentScreen instanceof StonecutterScreen stonecutterScreen) {
-            // TODO possible #251 bug point too
             List<RecipeEntry<StonecuttingRecipe>> list = stonecutterScreen.getScreenHandler().getAvailableRecipes();
             if (list.size() == 0) return "";
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/inventory_controls/SlotItem.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/inventory_controls/SlotItem.java
@@ -5,6 +5,7 @@ import com.github.khanshoaib3.minecraft_access.mixin.MerchantScreenAccessor;
 import com.github.khanshoaib3.minecraft_access.mixin.StonecutterScreenAccessor;
 import net.minecraft.block.entity.BannerPattern;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.LoomScreen;
 import net.minecraft.client.gui.screen.ingame.MerchantScreen;
 import net.minecraft.client.gui.screen.ingame.StonecutterScreen;
@@ -72,7 +73,7 @@ public class SlotItem {
     public String getNarratableText() {
         if (MinecraftClient.getInstance().currentScreen instanceof LoomScreen loomScreen) {
             List<RegistryEntry<BannerPattern>> list = loomScreen.getScreenHandler().getBannerPatterns();
-            if (list.size() == 0) return "";
+            if (list.isEmpty()) return "";
 
             int p = row + ((LoomScreenAccessor) loomScreen).getVisibleTopRow();
             int q = p * 4 + column;
@@ -82,11 +83,11 @@ public class SlotItem {
 
         if (MinecraftClient.getInstance().currentScreen instanceof StonecutterScreen stonecutterScreen) {
             List<RecipeEntry<StonecuttingRecipe>> list = stonecutterScreen.getScreenHandler().getAvailableRecipes();
-            if (list.size() == 0) return "";
+            if (list.isEmpty()) return "";
 
             int scrollOffset = ((StonecutterScreenAccessor) stonecutterScreen).getScrollOffset();
             ItemStack item = list.get(recipeOrTradeIndex + scrollOffset).value().getResult(DynamicRegistryManager.EMPTY);
-            List<Text> toolTip = MinecraftClient.getInstance().currentScreen.getTooltipFromItem(MinecraftClient.getInstance(),item);
+            List<Text> toolTip = Screen.getTooltipFromItem(MinecraftClient.getInstance(),item);
             StringBuilder toolTipString = new StringBuilder();
             for (Text text : toolTip) {
                 toolTipString.append(text.getString()).append("\n");

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/inventory_controls/SlotItem.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/inventory_controls/SlotItem.java
@@ -81,6 +81,7 @@ public class SlotItem {
         }
 
         if (MinecraftClient.getInstance().currentScreen instanceof StonecutterScreen stonecutterScreen) {
+            // TODO possible #251 bug point too
             List<RecipeEntry<StonecuttingRecipe>> list = stonecutterScreen.getScreenHandler().getAvailableRecipes();
             if (list.size() == 0) return "";
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonAccessor.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonAccessor.java
@@ -2,7 +2,7 @@ package com.github.khanshoaib3.minecraft_access.mixin;
 
 import net.minecraft.client.gui.screen.recipebook.AnimatedResultButton;
 import net.minecraft.client.gui.screen.recipebook.RecipeResultCollection;
-import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.gen.Invoker;
@@ -11,8 +11,9 @@ import java.util.List;
 
 @Mixin(AnimatedResultButton.class)
 public interface AnimatedResultButtonAccessor {
+    // pre 1.20.4: List<Recipe<?>> callGetResults();
     @Invoker
-    List<Recipe<?>> callGetResults();
+    List<RecipeEntry<?>> callGetResults();
 
     @Accessor
     RecipeResultCollection getResultCollection();

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonMixin.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonMixin.java
@@ -8,12 +8,15 @@ import net.minecraft.client.gui.screen.recipebook.AnimatedResultButton;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.DynamicRegistryManager;
+import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+// TODO remove the @Debug annotation after fixing bug
+@Debug(export = true)
 @Mixin(AnimatedResultButton.class)
 public class AnimatedResultButtonMixin {
     @Unique
@@ -28,6 +31,7 @@ public class AnimatedResultButtonMixin {
     //    @Inject(at = @At("HEAD"), method = "appendNarrations", cancellable = true) // Pre 1.19.3
     @Inject(at = @At("HEAD"), method = "appendClickableNarrations", cancellable = true) // From 1.19.3
     private void appendNarrations(NarrationMessageBuilder builder, CallbackInfo callbackInfo) {
+        // TODO here causes #251 bug
         ItemStack itemStack = ((AnimatedResultButtonAccessor) this).callGetResults().get(((AnimatedResultButtonAccessor) this).getCurrentResultIndex()).getResult(DynamicRegistryManager.EMPTY);
         String itemName = itemStack.getName().getString();
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonMixin.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/mixin/AnimatedResultButtonMixin.java
@@ -7,16 +7,16 @@ import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.screen.recipebook.AnimatedResultButton;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.registry.DynamicRegistryManager;
-import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-// TODO remove the @Debug annotation after fixing bug
-@Debug(export = true)
+import java.util.List;
+
 @Mixin(AnimatedResultButton.class)
 public class AnimatedResultButtonMixin {
     @Unique
@@ -31,8 +31,9 @@ public class AnimatedResultButtonMixin {
     //    @Inject(at = @At("HEAD"), method = "appendNarrations", cancellable = true) // Pre 1.19.3
     @Inject(at = @At("HEAD"), method = "appendClickableNarrations", cancellable = true) // From 1.19.3
     private void appendNarrations(NarrationMessageBuilder builder, CallbackInfo callbackInfo) {
-        // TODO here causes #251 bug
-        ItemStack itemStack = ((AnimatedResultButtonAccessor) this).callGetResults().get(((AnimatedResultButtonAccessor) this).getCurrentResultIndex()).getResult(DynamicRegistryManager.EMPTY);
+        List<RecipeEntry<?>> recipes = ((AnimatedResultButtonAccessor) this).callGetResults();
+        RecipeEntry<?> recipe = recipes.get(((AnimatedResultButtonAccessor) this).getCurrentResultIndex());
+        ItemStack itemStack = recipe.value().getResult(DynamicRegistryManager.EMPTY);
         String itemName = itemStack.getName().getString();
 
         boolean sameItem = itemName.equalsIgnoreCase(minecraft_access$previousItemName);

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,14 +1,18 @@
+Release v1.5.2 (2024-01)
+---------------------------
+
+### Bug Fixes
+
+* Fix the bug that locking on Entity will immediately unlock [#248](https://github.com/khanshoaib3/minecraft_access/issues/248)
+* Fix the bug that mod's INFO log will be logged twice in console and log files [#247](https://github.com/khanshoaib3/minecraft_access/issues/247)
+* Fix the bug that speaking recipes in Inventory Screen will cause the game crush. [#251](https://github.com/khanshoaib3/minecraft_access/issues/251)
+
 Release v1.5.1 (2024-01)
 ---------------------------
 
 ### Feature Changes
 
 * Add a new config "Speak Focused Slot Changes" with default "true" value for "Inventory Controls" feature. Close this config if you hear the mod is continuously repeating changes of item name. [#242](https://github.com/khanshoaib3/minecraft_access/issues/242)
-
-### Bug Fixes
-
-* Fix the bug that locking on Entity will immediately unlock [#248](https://github.com/khanshoaib3/minecraft_access/issues/248)
-* Fix the bug that mod's INFO log will be logged twice in console and log files [#247](https://github.com/khanshoaib3/minecraft_access/issues/247)
 
 Release v1.5.0 (2024-01)
 ---------------------------

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ fabric_yarn_version=1.20.4+build.1:v2
 enabled_platforms=fabric,forge
 
 archives_base_name=minecraft-access
-mod_version=1.5.1+1.20.4
+mod_version=1.5.2+1.20.4
 maven_group=com.github.khanshoaib3.minecraft_access
 
 # https://maven.architectury.dev/dev/architectury/


### PR DESCRIPTION
## Pull Request Checklist

[//]: # (Use `~~ -[ ] ... ~~` markdown deletion syntax to cross out unrelated entries)

~~- [ ] A new fragment is added in `./doc/news` that describes what is new (refer to issue #174).~~
- [x] The unit test suite passes at the latest commit of this PR branch.

## Describe what you have changed in this PR

Will release this fix as version 1.5.2.
Since I can't change the position of git tag `v1.5.1-1.20`, add previous two bug fixes to 1.5.2 version too.