### PR TITLE
Fix checkout action ref error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
       version:
         default: 'latest'
         required: false
-        description: Version to be published (git tag like 'v1.5.2-1.20.4', default to extract from gradle.properties)
+        description: Version to be published (git tag like 'v1.5.2-1.20.4', default to extract from gradle.properties, DO use default value to build the latest version)
 
   # workflow_call: Or it will be triggered by release workflow
   # ref: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_call
@@ -48,9 +48,6 @@ jobs:
   build:
     # Run build job only if test job is successfully passed
     # ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds
-    #
-    # assignment syntax: ${{ condition && return-if-true || return-if-false }}
-    # ref: https://docs.github.com/en/actions/learn-github-actions/expressions#example
     #
     # ref='' for default value (HEAD of main branch) of checkout action
     # ref: https://github.com/actions/checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,12 @@ jobs:
   build:
     # Run build job only if test job is successfully passed
     # ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds
+    #
+    # assignment syntax: ${{ condition && return-if-true || return-if-false }}
+    # ref: https://docs.github.com/en/actions/learn-github-actions/expressions#example
+    #
+    # ref='' for default value (HEAD of main branch) of checkout action
+    # ref: https://github.com/actions/checkout
     name: Run Gradle Build and Preserve Build Files
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,15 +57,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.version == 'latest' && '' || inputs.version }}
+          ref: ${{ inputs.version == 'latest' && github.ref || inputs.version }}
 
-      - name: Fetch latest I18N files
+      - name: Fetch Latest Lang Assert
+        if: ${{ inputs.version == 'latest' }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.version == 'latest' && '' || inputs.version }}
-          # From another repo
+          # ref: https://github.com/khanshoaib3/minecraft-access
           repository: 'khanshoaib3/minecraft-access-i18n'
           # Checkout the repo in mod's language assert path
+          path: './common/src/main/resources/assets/minecraft_access/lang'
+
+      - name: Fetch Lang Assert at Given Version
+        if: ${{ inputs.version != 'latest' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+          repository: 'khanshoaib3/minecraft-access-i18n'
           path: './common/src/main/resources/assets/minecraft_access/lang'
 
       - name: Set up JDK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,12 +58,12 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.version == 'latest' && '' || inputs.version }}
 
       - name: Fetch latest I18N files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.version == 'latest' && '' || inputs.version }}
           # From another repo

--- a/.github/workflows/post_github_release.yml
+++ b/.github/workflows/post_github_release.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # github.repository: owner/repo
       # Release API ref: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release-by-tag-name

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     with:
       jdk-version: '17'
       build-files-cache-key: ${{ github.run_id }}
-      version: ${{ inputs.version || 'latest' }}
+      version: ${{ inputs.version }}
 
   publish:
     name: Publish
@@ -64,7 +64,7 @@ jobs:
       # there is no need to modify steps below this checkout step
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.version == 'latest' && '' || inputs.version }}
+          ref: ${{ inputs.version == 'latest' && github.ref || inputs.version }}
 
       - name: Restore Cached Mod Files
         uses: actions/cache/restore@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
       version:
         default: 'latest'
         required: false
-        description: Version to be published (git tag like 'v1.5.2-1.20.4', default to extract from gradle.properties)
+        description: Version to be published (git tag like 'v1.5.2-1.20.4', default to extract from gradle.properties, DO use default value for pre-release the latest version)
         type: string
       note:
         default: ''
@@ -32,7 +32,7 @@ env:
   UPLOAD_PATH: upload
   CHANGELOG_FILE_PATH: ./doc/CHANGELOG.md
   MOD_COMPATIBILITY_INFO_FILE_PATH: ./doc/MOD_COMPATIBILITY.md
-  # Release body for github release
+  # Release body for GitHub release
   CHANGELOG_TEMP_GITHUB: .changelog_github.md
   # Release body for modrinth, curseforge
   CHANGELOG_TEMP_PLATFORM: .changelog_platform.md
@@ -60,7 +60,7 @@ jobs:
     outputs:
       release-tag: ${{ steps.env-gradle.outputs.release-tag || inputs.version }}
     steps:
-      # As long as we checkout right commit at first,
+      # As long as we check out right commit at first,
       # there is no need to modify steps below this checkout step
       - uses: actions/checkout@v3
         with:
@@ -179,7 +179,7 @@ jobs:
           game-versions: ${{ env.MINECRAFT_VERSION }}
           java: ${{ env.JAVA_VERSION }}
           dependencies: |
-            architectury-api@${{ env.ARCHY_VERSION }}+forge(required)
+            architectury-api@${{ env.ARCHY_VERSION }}+minecraftforge(required)
           retry-attempts: 2
           retry-delay: 60000
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     # ref: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
     outputs:
-      release-tag: ${{ steps.env-gradle.outputs.release-tag || inputs.version }}
+      release-tag: ${{ steps.env.outputs.release-tag || inputs.version }}
     steps:
       # As long as we check out right commit at first,
       # there is no need to modify steps below this checkout step

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       # As long as we check out right commit at first,
       # there is no need to modify steps below this checkout step
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.version == 'latest' && '' || inputs.version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     if: ${{ inputs.version == 'latest' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Pull Request Checklist

[//]: # (Use `~~ -[ ] ... ~~` markdown deletion syntax to cross out unrelated entries)

~~- [ ] A new fragment is added in `./doc/news` that describes what is new (refer to issue #174).~~

## Describe what you have changed in this PR

Fix the bug in `build` workflow that checkout action don't know which branch to pull, like
https://github.com/khanshoaib3/minecraft-access/actions/runs/7669355266/job/20903433017