### PR TITLE
Some improvements, some refactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,8 +122,7 @@ jobs:
             >> ${{ env.CHANGELOG_TEMP_GITHUB }}
           
           cp .changelog_temp ${{ env.CHANGELOG_TEMP_PLATFORM }}
-          GH_LINK="For additional information about this release, please check [this GitHub release page](https://github.com/khanshoaib3/minecraft-access/releases/tag/)."
-          printf ${GH_LINK} >> ${{ env.CHANGELOG_TEMP_PLATFORM }}
+          printf "For additional information about this release, please check [this GitHub release page](https://github.com/khanshoaib3/minecraft-access/releases/tag/)." >> ${{ env.CHANGELOG_TEMP_PLATFORM }}
 
       # Action ref: https://github.com/Kir-Antipov/mc-publish
       - name: Create Github Release

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/FacingDirection.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/FacingDirection.java
@@ -2,7 +2,6 @@ package com.github.khanshoaib3.minecraft_access.features;
 
 import com.github.khanshoaib3.minecraft_access.MainClass;
 import com.github.khanshoaib3.minecraft_access.utils.KeyBindingsHandler;
-import com.github.khanshoaib3.minecraft_access.utils.NarrationUtils;
 import com.github.khanshoaib3.minecraft_access.utils.position.PlayerPositionUtils;
 import com.github.khanshoaib3.minecraft_access.utils.system.KeyUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -29,19 +28,11 @@ public class FacingDirection {
 
             String toSpeak;
             if (isLeftAltPressed) {
-                int angle = new PlayerPositionUtils(minecraftClient).getVerticalFacingDirection();
-                toSpeak = NarrationUtils.narrateNumber(angle);
+                String t = new PlayerPositionUtils(minecraftClient).getVerticalFacingDirectionInWords();
+                toSpeak = I18n.translate("minecraft_access.other.facing_direction", t);
             } else {
-
-                /* TODO add to config and add left alt combination to readme
-                int angle = new PlayerPositionUtils(minecraftClient).getHorizontalFacingDirectionInDegrees();
-                if (Config.get(Config.getCardinal_to_Degrees_Key())) {
-                    toSpeak += angle;
-                } else {
-                */
                 String string = new PlayerPositionUtils(minecraftClient).getHorizontalFacingDirectionInCardinal();
                 toSpeak = I18n.translate("minecraft_access.other.facing_direction", string);
-                // }
             }
 
             MainClass.speakWithNarrator(toSpeak, true);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
@@ -37,7 +37,8 @@ public class ReadCrosshair {
     private static final double RAY_CAST_DISTANCE = 6.0;
     private static ReadCrosshair instance;
     private boolean enabled;
-    private String previousQuery;
+    private String previousQuery = "";
+    private Vec3d previousSoundPos = Vec3d.ZERO;
     private boolean speakSide;
     private boolean speakingConsecutiveBlocks;
     private Interval repeatSpeakingInterval;
@@ -52,7 +53,6 @@ public class ReadCrosshair {
     private double maxSoundVolume;
 
     private ReadCrosshair() {
-        previousQuery = "";
         loadConfigurations();
     }
 
@@ -160,9 +160,10 @@ public class ReadCrosshair {
     private void speakIfFocusChanged(String currentQuery, String toSpeak, Vec3d targetPosition) {
         boolean focusChanged = !getPreviousQuery().equalsIgnoreCase(currentQuery);
         if (focusChanged) {
-            if (this.enableRelativePositionSoundCue) {
+            if (this.enableRelativePositionSoundCue && !this.previousSoundPos.equals(targetPosition)) {
                 WorldUtils.playRelativePositionSoundCue(targetPosition, RAY_CAST_DISTANCE,
                         SoundEvents.BLOCK_NOTE_BLOCK_HARP, this.minSoundVolume, this.maxSoundVolume);
+                this.previousSoundPos = targetPosition;
             }
             this.previousQuery = currentQuery;
             MainClass.speakWithNarrator(toSpeak, true);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
@@ -178,7 +178,7 @@ public class ReadCrosshair {
         }
 
         BlockPos blockPos = hit.getBlockPos();
-        WorldUtils.BlockInfo blockInfo = WorldUtils.getBlockInfo(blockPos).orElseThrow();
+        WorldUtils.BlockInfo blockInfo = WorldUtils.getBlockInfo(blockPos);
         // In Minecraft resource location format, for example, "oak_door" for Oak Door.
         // ref: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
         Identifier blockId = Registries.BLOCK.getId(blockInfo.type());

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
@@ -81,19 +81,9 @@ public class ReadCrosshair {
             loadConfigurations();
             if (!enabled) return;
 
-            HitResult hit = minecraftClient.crosshairTarget;
+            HitResult hit = PlayerUtils.crosshairTarget(RAY_CAST_DISTANCE);
             if (hit == null) return;
-
-            // Speak fluid if player isn't in fluid and is looking at a fluid block
-            BlockHitResult fluidHitResult = PlayerUtils.crosshairFluidTarget(RAY_CAST_DISTANCE);
-            if (HitResult.Type.BLOCK.equals(fluidHitResult.getType()) && PlayerUtils.isNotInFluid()) {
-                BlockPos fPos = fluidHitResult.getBlockPos();
-                String toSpeak = NarrationUtils.narrateFluidBlock(fPos);
-                String currentQuery = this.speakingConsecutiveBlocks ? toSpeak + fPos : toSpeak;
-                speakIfFocusChanged(currentQuery, toSpeak, Vec3d.of(fPos));
-            } else {
-                checkForBlockAndEntityHit(hit);
-            }
+            checkForBlockAndEntityHit(hit);
 
         } catch (Exception e) {
             log.error("Error occurred in read block feature.", e);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/ReadCrosshair.java
@@ -86,7 +86,7 @@ public class ReadCrosshair {
 
             // Speak fluid if player isn't in fluid and is looking at a fluid block
             BlockHitResult fluidHitResult = PlayerUtils.crosshairFluidTarget(RAY_CAST_DISTANCE);
-            if (HitResult.Type.BLOCK.equals(fluidHitResult.getType()) && !PlayerUtils.isInFluid()) {
+            if (HitResult.Type.BLOCK.equals(fluidHitResult.getType()) && PlayerUtils.isNotInFluid()) {
                 BlockPos fPos = fluidHitResult.getBlockPos();
                 String toSpeak = NarrationUtils.narrateFluidBlock(fPos);
                 String currentQuery = this.speakingConsecutiveBlocks ? toSpeak + fPos : toSpeak;

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/narrator_menu/NarratorMenu.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/narrator_menu/NarratorMenu.java
@@ -8,24 +8,19 @@ import com.github.khanshoaib3.minecraft_access.screen_reader.ScreenReaderControl
 import com.github.khanshoaib3.minecraft_access.utils.KeyBindingsHandler;
 import com.github.khanshoaib3.minecraft_access.utils.NarrationUtils;
 import com.github.khanshoaib3.minecraft_access.utils.PlayerUtils;
-import com.github.khanshoaib3.minecraft_access.utils.WorldUtils;
 import com.github.khanshoaib3.minecraft_access.utils.condition.Keystroke;
 import com.github.khanshoaib3.minecraft_access.utils.condition.MenuKeystroke;
 import com.github.khanshoaib3.minecraft_access.utils.system.KeyUtils;
 import lombok.extern.slf4j.Slf4j;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.registry.entry.RegistryEntry;
-import net.minecraft.text.MutableText;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.biome.Biome;
-import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.Arrays;
@@ -175,23 +170,15 @@ public class NarratorMenu {
 
     public static void getBlockAndFluidTargetInformation() {
         try {
-            HitResult hit = getBlockAndFluidHitResult();
+            HitResult hit = PlayerUtils.crosshairTarget(RAY_CAST_DISTANCE);
             if (hit == null) return;
-
-            if (PlayerUtils.isNotInFluid() && checkForFluidHit(minecraftClient, hit, false)) return;
-
             switch (hit.getType()) {
                 case MISS, ENTITY -> MainClass.speakWithNarrator(I18n.translate("minecraft_access.narrator_menu.target_missed"), true);
                 case BLOCK -> {
                     try {
                         BlockHitResult blockHit = (BlockHitResult) hit;
                         BlockPos blockPos = blockHit.getBlockPos();
-
-                        BlockState blockState = WorldUtils.getClientWorld().orElseThrow().getBlockState(blockPos);
-                        Block block = blockState.getBlock();
-                        MutableText mutableText = block.getName();
-
-                        String text = mutableText.getString() + ", " + NarrationUtils.narrateRelativePositionOfPlayerAnd(blockPos);
+                        String text = NarrationUtils.narrateBlock(blockPos, "") + ", " + NarrationUtils.narrateRelativePositionOfPlayerAnd(blockPos);
                         MainClass.speakWithNarrator(text, true);
                     } catch (Exception e) {
                         log.error("An error occurred when speaking block information.", e);
@@ -203,24 +190,10 @@ public class NarratorMenu {
         }
     }
 
-    @Nullable
-    private static HitResult getBlockAndFluidHitResult() {
-        if (minecraftClient.player == null) return null;
-        if (minecraftClient.cameraEntity == null) return null;
-        if (minecraftClient.world == null) return null;
-
-        minecraftClient.player.closeScreen();
-
-        return minecraftClient.cameraEntity.raycast(RAY_CAST_DISTANCE, 0.0f, true);
-    }
-
     public static void getBlockAndFluidTargetPosition() {
         try {
-            HitResult hit = getBlockAndFluidHitResult();
+            HitResult hit = PlayerUtils.crosshairTarget(RAY_CAST_DISTANCE);
             if (hit == null) return;
-
-            if (PlayerUtils.isNotInFluid() && checkForFluidHit(minecraftClient, hit, true)) return;
-
             switch (hit.getType()) {
                 case MISS, ENTITY -> MainClass.speakWithNarrator(I18n.translate("minecraft_access.narrator_menu.target_missed"), true);
                 case BLOCK -> {
@@ -236,24 +209,6 @@ public class NarratorMenu {
         } catch (Exception e) {
             log.error("An error occurred when getting block and target position.", e);
         }
-    }
-
-    public static boolean checkForFluidHit(MinecraftClient minecraftClient, HitResult fluidHit, boolean onlyPosition) {
-        if (minecraftClient == null) return false;
-        if (minecraftClient.world == null) return false;
-        if (minecraftClient.currentScreen != null) return false;
-
-        if (fluidHit.getType() == HitResult.Type.BLOCK) {
-            BlockPos blockPos = ((BlockHitResult) fluidHit).getBlockPos();
-            if (onlyPosition) {
-                MainClass.speakWithNarrator(NarrationUtils.narrateCoordinatesOf(blockPos), true);
-                return true;
-            }
-
-            MainClass.speakWithNarrator(NarrationUtils.narrateFluidBlock(blockPos), true);
-            return true;
-        }
-        return false;
     }
 
     public static void getLightLevel() {

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/narrator_menu/NarratorMenu.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/narrator_menu/NarratorMenu.java
@@ -4,7 +4,6 @@ import com.github.khanshoaib3.minecraft_access.MainClass;
 import com.github.khanshoaib3.minecraft_access.config.ConfigMenu;
 import com.github.khanshoaib3.minecraft_access.config.config_maps.OtherConfigsMap;
 import com.github.khanshoaib3.minecraft_access.features.BiomeIndicator;
-import com.github.khanshoaib3.minecraft_access.features.ReadCrosshair;
 import com.github.khanshoaib3.minecraft_access.screen_reader.ScreenReaderController;
 import com.github.khanshoaib3.minecraft_access.utils.KeyBindingsHandler;
 import com.github.khanshoaib3.minecraft_access.utils.NarrationUtils;
@@ -20,7 +19,6 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.InputUtil;
-import net.minecraft.fluid.FluidState;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.text.MutableText;
 import net.minecraft.util.hit.BlockHitResult;
@@ -247,25 +245,12 @@ public class NarratorMenu {
 
         if (fluidHit.getType() == HitResult.Type.BLOCK) {
             BlockPos blockPos = ((BlockHitResult) fluidHit).getBlockPos();
-            FluidState fluidState = minecraftClient.world.getFluidState(blockPos);
-
-            String name = ReadCrosshair.getFluidName(fluidState.getRegistryEntry());
-            if (name.equals("block.minecraft.empty")) return false;
-            if (name.contains("block.minecraft."))
-                name = name.replace("block.minecraft.", ""); // Remove `block.minecraft.` for unsupported languages
-
             if (onlyPosition) {
                 MainClass.speakWithNarrator(NarrationUtils.narrateCoordinatesOf(blockPos), true);
                 return true;
             }
 
-            int level = fluidState.getLevel();
-            String levelString = "";
-            if (level < 8) levelString = I18n.translate("minecraft_access.read_crosshair.fluid_level", level);
-
-            String toSpeak = name + levelString + ", " + NarrationUtils.narrateRelativePositionOfPlayerAnd(blockPos);
-
-            MainClass.speakWithNarrator(toSpeak, true);
+            MainClass.speakWithNarrator(NarrationUtils.narrateFluidBlock(blockPos), true);
             return true;
         }
         return false;

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/narrator_menu/NarratorMenu.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/narrator_menu/NarratorMenu.java
@@ -246,7 +246,10 @@ public class NarratorMenu {
 
             minecraftClient.player.closeScreen();
 
-            MainClass.speakWithNarrator(I18n.translate("minecraft_access.narrator_menu.xp", PlayerUtils.getExperienceLevel(), PlayerUtils.getExperienceProgress()), true);
+            MainClass.speakWithNarrator(I18n.translate("minecraft_access.narrator_menu.xp",
+                    PlayerUtils.getExperienceLevel(),
+                    PlayerUtils.getExperienceProgress()),
+                    true);
         } catch (Exception e) {
             log.error("An error occurred when getting XP.", e);
         }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/narrator_menu/NarratorMenu.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/narrator_menu/NarratorMenu.java
@@ -178,7 +178,7 @@ public class NarratorMenu {
             HitResult hit = getBlockAndFluidHitResult();
             if (hit == null) return;
 
-            if (!PlayerUtils.isInFluid() && checkForFluidHit(minecraftClient, hit, false)) return;
+            if (PlayerUtils.isNotInFluid() && checkForFluidHit(minecraftClient, hit, false)) return;
 
             switch (hit.getType()) {
                 case MISS, ENTITY -> MainClass.speakWithNarrator(I18n.translate("minecraft_access.narrator_menu.target_missed"), true);
@@ -219,7 +219,7 @@ public class NarratorMenu {
             HitResult hit = getBlockAndFluidHitResult();
             if (hit == null) return;
 
-            if (!PlayerUtils.isInFluid() && checkForFluidHit(minecraftClient, hit, true)) return;
+            if (PlayerUtils.isNotInFluid() && checkForFluidHit(minecraftClient, hit, true)) return;
 
             switch (hit.getType()) {
                 case MISS, ENTITY -> MainClass.speakWithNarrator(I18n.translate("minecraft_access.narrator_menu.target_missed"), true);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/LockingHandler.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/LockingHandler.java
@@ -233,7 +233,7 @@ public class LockingHandler {
     private void lockOnBlock(Vec3d position) {
         unlock(false);
 
-        BlockState blockState = WorldUtils.getClientWorld().orElseThrow().getBlockState(new BlockPos3d(position));
+        BlockState blockState = WorldUtils.getClientWorld().getBlockState(new BlockPos3d(position));
         entriesOfLockedOnBlock = blockState.getEntries().toString();
 
         Vec3d absolutePosition = position;

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/NonCubeBlockAbsolutePositions.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/NonCubeBlockAbsolutePositions.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.Vec3d;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * The position of the block (blockPos.toCenterPos()) is generally considered to be the center of the block (x.5,y.5,z.5).
@@ -19,10 +18,8 @@ import java.util.Optional;
  */
 public class NonCubeBlockAbsolutePositions {
     public static Vec3d getTrapDoorPos(Vec3d blockPos) {
-        Optional<ClientWorld> world = WorldUtils.getClientWorld();
-        if (world.isEmpty()) return blockPos;
-
-        ImmutableSet<Map.Entry<Property<?>, Comparable<?>>> entries = getEntries(blockPos, world.get());
+        ClientWorld world = WorldUtils.getClientWorld();
+        ImmutableSet<Map.Entry<Property<?>, Comparable<?>>> entries = getEntries(blockPos, world);
 
         String half = "", facing = "", open = "";
 
@@ -62,10 +59,8 @@ public class NonCubeBlockAbsolutePositions {
     }
 
     public static Vec3d getLeverPos(Vec3d blockPos) {
-        Optional<ClientWorld> world = WorldUtils.getClientWorld();
-        if (world.isEmpty()) return blockPos;
-
-        ImmutableSet<Map.Entry<Property<?>, Comparable<?>>> entries = getEntries(blockPos, world.get());
+        ClientWorld world = WorldUtils.getClientWorld();
+        ImmutableSet<Map.Entry<Property<?>, Comparable<?>>> entries = getEntries(blockPos, world);
 
         String face = "", facing = "";
 
@@ -103,10 +98,8 @@ public class NonCubeBlockAbsolutePositions {
     }
 
     public static Vec3d getLadderPos(Vec3d blockPos) {
-        Optional<ClientWorld> world = WorldUtils.getClientWorld();
-        if (world.isEmpty()) return blockPos;
-
-        ImmutableSet<Map.Entry<Property<?>, Comparable<?>>> entries = getEntries(blockPos, world.get());
+        ClientWorld world = WorldUtils.getClientWorld();
+        ImmutableSet<Map.Entry<Property<?>, Comparable<?>>> entries = getEntries(blockPos, world);
 
         String facing = "";
 
@@ -136,10 +129,8 @@ public class NonCubeBlockAbsolutePositions {
     }
 
     public static Vec3d getButtonPos(Vec3d blockPos) {
-        Optional<ClientWorld> world = WorldUtils.getClientWorld();
-        if (world.isEmpty()) return blockPos;
-
-        ImmutableSet<Map.Entry<Property<?>, Comparable<?>>> entries = getEntries(blockPos, world.get());
+        ClientWorld world = WorldUtils.getClientWorld();
+        ImmutableSet<Map.Entry<Property<?>, Comparable<?>>> entries = getEntries(blockPos, world);
 
         double x = blockPos.getX();
         double y = blockPos.getY();
@@ -176,10 +167,8 @@ public class NonCubeBlockAbsolutePositions {
     }
 
     public static Vec3d getDoorPos(Vec3d blockPos) {
-        Optional<ClientWorld> world = WorldUtils.getClientWorld();
-        if (world.isEmpty()) return blockPos;
-
-        ImmutableSet<Map.Entry<Property<?>, Comparable<?>>> entries = getEntries(blockPos, world.get());
+        ClientWorld world = WorldUtils.getClientWorld();
+        ImmutableSet<Map.Entry<Property<?>, Comparable<?>>> entries = getEntries(blockPos, world);
 
         String facing = "", hinge = "", open = "";
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
@@ -265,7 +265,7 @@ public class POIBlocks {
         }
     }
 
-    public void setMarkedBlock(Block block) {
+    private void setMarkedBlock(Block block) {
         this.markedBlock = block == null ? s -> false : s -> s.isOf(block);
     }
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
@@ -281,9 +281,14 @@ public class POIBlocks {
     }
 
     public List<TreeMap<Double, Vec3d>> getLockingCandidates() {
-        boolean suppressLockingOnNonMarkedThings = onPOIMarkingNow && POIMarkingConfigMap.getInstance().isSuppressOtherWhenEnabled();
-        return suppressLockingOnNonMarkedThings ?
-                List.of(markedBlocks) :
-                List.of(doorBlocks, buttonBlocks, ladderBlocks, leverBlocks, trapDoorBlocks, otherBlocks, oreBlocks, fluidBlocks, markedBlocks);
+        if (onPOIMarkingNow) {
+            if (POIMarkingConfigMap.getInstance().isSuppressOtherWhenEnabled()) {
+                return List.of(markedBlocks);
+            } else {
+                return List.of(markedBlocks, doorBlocks, buttonBlocks, ladderBlocks, leverBlocks, trapDoorBlocks, otherBlocks, oreBlocks, fluidBlocks);
+            }
+        } else {
+            return List.of(doorBlocks, buttonBlocks, ladderBlocks, leverBlocks, trapDoorBlocks, otherBlocks, oreBlocks, fluidBlocks);
+        }
     }
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
@@ -68,7 +68,8 @@ public class POIBlocks {
             Blocks.DEEPSLATE_LAPIS_ORE,
             Blocks.REDSTONE_ORE,
             Blocks.DEEPSLATE_REDSTONE_ORE,
-            Blocks.NETHER_QUARTZ_ORE
+            Blocks.NETHER_QUARTZ_ORE,
+            Blocks.ANCIENT_DEBRIS
     };
 
     private static final List<Predicate<BlockState>> oreBlockPredicates = Arrays.stream(ORE_BLOCKS)

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
@@ -84,7 +84,7 @@ public class POIBlocks {
     private TreeMap<Double, Vec3d> otherBlocks = new TreeMap<>();
     private TreeMap<Double, Vec3d> markedBlocks = new TreeMap<>();
 
-    private List<Vec3d> checkedBlocks = new ArrayList<>();
+    private Set<BlockPos> checkedBlocks = Set.of();
     private boolean enabled;
     private boolean detectFluidBlocks;
     private int range;
@@ -136,7 +136,7 @@ public class POIBlocks {
             markedBlocks = new TreeMap<>();
 
             // Player position is where player's leg be
-            checkedBlocks = new ArrayList<>();
+            checkedBlocks = new HashSet<>();
             BlockPos pos = minecraftClient.player.getBlockPos();
             log.debug("POIBlock started.");
             // Scan blocks above and below player,
@@ -175,8 +175,8 @@ public class POIBlocks {
         double posX = blockPos.getX(), posY = blockPos.getY(), posZ = blockPos.getZ();
         Vec3d blockVec3dPos = Vec3d.ofCenter(blockPos);
 
-        if (checkedBlocks.contains(blockVec3dPos)) return;
-        checkedBlocks.add(blockVec3dPos);
+        if (checkedBlocks.contains(blockPos)) return;
+        checkedBlocks.add(blockPos);
 
         double diff = playerVec3dPos.distanceTo(blockVec3dPos);
         String soundType = "";

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
@@ -235,34 +235,38 @@ public class POIBlocks {
             soundType = "blocksWithInterface";
         }
 
-        if (this.playSound && this.volume > 0 && !soundType.isEmpty()) {
-            String coordinates = NarrationUtils.narrateCoordinatesOf(blockPos);
+        boolean playSound = this.playSound && !soundType.isEmpty() && this.volume != 0;
+        if (playSound) playSoundAtBlock(blockPos, soundType);
+    }
 
-            if (soundType.equalsIgnoreCase("mark")) {
-                log.debug("{POIBlocks} Playing sound at " + coordinates);
-                minecraftClient.world.playSound(minecraftClient.player, blockPos, SoundEvents.ENTITY_ITEM_PICKUP,
-                        SoundCategory.BLOCKS, volume, -5f);
-            }
+    private void playSoundAtBlock(BlockPos blockPos, String soundType) {
+        if (minecraftClient.world == null) return;
+        String coordinates = NarrationUtils.narrateCoordinatesOf(blockPos);
 
-            if (onPOIMarkingNow && POIMarkingConfigMap.getInstance().isSuppressOtherWhenEnabled()) {
-                if (!soundType.equalsIgnoreCase("mark")) {
-                    log.debug("{POIBlocks} Suppress sound at " + coordinates);
-                }
-                return;
-            }
-
+        if (soundType.equalsIgnoreCase("mark")) {
             log.debug("{POIBlocks} Playing sound at " + coordinates);
-
-            if (soundType.equalsIgnoreCase("ore"))
-                minecraftClient.world.playSound(minecraftClient.player, blockPos, SoundEvents.ENTITY_ITEM_PICKUP,
-                        SoundCategory.BLOCKS, volume, -5f);
-            else if (this.playSoundForOtherBlocks && soundType.equalsIgnoreCase("blocks"))
-                minecraftClient.world.playSound(minecraftClient.player, blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BIT.value(),
-                        SoundCategory.BLOCKS, volume, 2f);
-            else if (this.playSoundForOtherBlocks && soundType.equalsIgnoreCase("blocksWithInterface"))
-                minecraftClient.world.playSound(minecraftClient.player, blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BANJO.value(),
-                        SoundCategory.BLOCKS, volume, 0f);
+            minecraftClient.world.playSound(minecraftClient.player, blockPos, SoundEvents.ENTITY_ITEM_PICKUP,
+                    SoundCategory.BLOCKS, volume, -5f);
         }
+
+        if (onPOIMarkingNow && POIMarkingConfigMap.getInstance().isSuppressOtherWhenEnabled()) {
+            if (!soundType.equalsIgnoreCase("mark")) {
+                log.debug("{POIBlocks} Suppress sound at " + coordinates);
+            }
+            return;
+        }
+
+        log.debug("{POIBlocks} Playing sound at " + coordinates);
+
+        if (soundType.equalsIgnoreCase("ore"))
+            minecraftClient.world.playSound(minecraftClient.player, blockPos, SoundEvents.ENTITY_ITEM_PICKUP,
+                    SoundCategory.BLOCKS, volume, -5f);
+        else if (this.playSoundForOtherBlocks && soundType.equalsIgnoreCase("blocks"))
+            minecraftClient.world.playSound(minecraftClient.player, blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BIT.value(),
+                    SoundCategory.BLOCKS, volume, 2f);
+        else if (this.playSoundForOtherBlocks && soundType.equalsIgnoreCase("blocksWithInterface"))
+            minecraftClient.world.playSound(minecraftClient.player, blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BANJO.value(),
+                    SoundCategory.BLOCKS, volume, 0f);
     }
 
     private void setMarkedBlock(Block block) {

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
@@ -2,7 +2,6 @@ package com.github.khanshoaib3.minecraft_access.features.point_of_interest;
 
 import com.github.khanshoaib3.minecraft_access.config.config_maps.POIBlocksConfigMap;
 import com.github.khanshoaib3.minecraft_access.config.config_maps.POIMarkingConfigMap;
-import com.github.khanshoaib3.minecraft_access.utils.NarrationUtils;
 import com.github.khanshoaib3.minecraft_access.utils.PlayerUtils;
 import com.github.khanshoaib3.minecraft_access.utils.condition.Interval;
 import com.google.common.collect.ImmutableSet;
@@ -250,22 +249,21 @@ public class POIBlocks {
         boolean playSound = this.playSound && !soundType.isEmpty() && this.volume != 0;
         if (!playSound) return;
 
-        String coordinates = NarrationUtils.narrateCoordinatesOf(blockPos);
+        String coordinates = "x:%d y:%d z%d".formatted(blockPos.getX(), blockPos.getY(), blockPos.getZ());
 
-        if (soundType.equalsIgnoreCase("mark")) {
-            log.debug("{POIBlocks} Playing sound at " + coordinates);
-            this.world.playSound(this.player, blockPos, SoundEvents.ENTITY_ITEM_PICKUP,
-                    SoundCategory.BLOCKS, volume, -5f);
-        }
-
-        if (onPOIMarkingNow && POIMarkingConfigMap.getInstance().isSuppressOtherWhenEnabled()) {
-            if (!soundType.equalsIgnoreCase("mark")) {
-                log.debug("{POIBlocks} Suppress sound at " + coordinates);
+        if (onPOIMarkingNow) {
+            if (soundType.equalsIgnoreCase("mark")) {
+                log.debug("Play sound at [{}]", coordinates);
+                this.world.playSound(this.player, blockPos, SoundEvents.ENTITY_ITEM_PICKUP,
+                        SoundCategory.BLOCKS, volume, -5f);
+                return;
+            } else if (POIMarkingConfigMap.getInstance().isSuppressOtherWhenEnabled()) {
+                log.debug("Suppress sound at [{}]", coordinates);
+                return;
             }
-            return;
         }
 
-        log.debug("{POIBlocks} Playing sound at " + coordinates);
+        log.debug("Play sound at [{}]", coordinates);
 
         if (soundType.equalsIgnoreCase("ore"))
             this.world.playSound(this.player, blockPos, SoundEvents.ENTITY_ITEM_PICKUP,

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
@@ -186,8 +186,7 @@ public class POIBlocks {
         }
 
         String soundType = checkAndPutIntoMap(blockPos, blockState);
-        boolean playSound = this.playSound && !soundType.isEmpty() && this.volume != 0;
-        if (playSound) playSoundAtBlock(blockPos, soundType);
+        playSoundAtBlock(blockPos, soundType);
     }
 
     private String checkAndPutIntoMap(BlockPos blockPos, BlockState blockState) {
@@ -246,6 +245,9 @@ public class POIBlocks {
     }
 
     private void playSoundAtBlock(BlockPos blockPos, String soundType) {
+        boolean playSound = this.playSound && !soundType.isEmpty() && this.volume != 0;
+        if (!playSound) return;
+
         String coordinates = NarrationUtils.narrateCoordinatesOf(blockPos);
 
         if (soundType.equalsIgnoreCase("mark")) {

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
@@ -135,20 +135,16 @@ public class POIBlocks {
             otherBlocks = new TreeMap<>();
             markedBlocks = new TreeMap<>();
 
-            BlockPos pos = minecraftClient.player.getBlockPos();
-
-            int posX = pos.getX();
-            int posY = pos.getY() - 1;
-            int posZ = pos.getZ();
+            // Player position is where player's leg be
             checkedBlocks = new ArrayList<>();
-
-            log.debug("POIBlock started...");
-
-            checkBlock(new BlockPos(new Vec3i(posX, posY, posZ)), 0);
-            checkBlock(new BlockPos(new Vec3i(posX, posY + 3, posZ)), 0);
-            checkBlock(new BlockPos(new Vec3i(posX, posY + 1, posZ)), this.range);
-            checkBlock(new BlockPos(new Vec3i(posX, posY + 2, posZ)), this.range);
-
+            BlockPos pos = minecraftClient.player.getBlockPos();
+            log.debug("POIBlock started.");
+            // Scan blocks above and below player,
+            // then scan two layers of blocks that are at same height as player.
+            checkBlock(pos.down(), 0);
+            checkBlock(pos.up(2), 0);
+            checkBlock(pos, this.range);
+            checkBlock(pos.up(), this.range);
             log.debug("POIBlock ended.");
 
         } catch (Exception e) {

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
@@ -183,6 +183,8 @@ public class POIBlocks {
             checkBlock(blockPos.east(), vSubOne);
             checkBlock(blockPos.up(), vSubOne);
             checkBlock(blockPos.down(), vSubOne);
+            // Air block is not a valid POI block, so return early
+            return;
         }
 
         String soundType = checkAndPutIntoMap(blockPos, blockState);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
@@ -111,9 +111,10 @@ public class POIBlocks {
         loadConfigurations();
     }
 
-    public void update(boolean onMarking) {
+    public void update(boolean onMarking, Block markedBlock) {
         try {
             this.onPOIMarkingNow = onMarking;
+            if (onPOIMarkingNow) setMarkedBlock(markedBlock);
             loadConfigurations();
 
             if (!this.enabled) return;

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
@@ -185,6 +185,12 @@ public class POIBlocks {
             checkBlock(blockPos.down(), vSubOne);
         }
 
+        String soundType = checkAndPutIntoMap(blockPos, blockState);
+        boolean playSound = this.playSound && !soundType.isEmpty() && this.volume != 0;
+        if (playSound) playSoundAtBlock(blockPos, soundType);
+    }
+
+    private String checkAndPutIntoMap(BlockPos blockPos, BlockState blockState) {
         String soundType = "";
         Block block = blockState.getBlock();
         Vec3d blockVec3dPos = blockPos.toCenterPos();
@@ -236,9 +242,7 @@ public class POIBlocks {
             otherBlocks.put(diff, blockVec3dPos);
             soundType = "blocksWithInterface";
         }
-
-        boolean playSound = this.playSound && !soundType.isEmpty() && this.volume != 0;
-        if (playSound) playSoundAtBlock(blockPos, soundType);
+        return soundType;
     }
 
     private void playSoundAtBlock(BlockPos blockPos, String soundType) {

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIBlocks.java
@@ -184,7 +184,7 @@ public class POIBlocks {
         if (markedBlock.test(blockState)) {
             markedBlocks.put(diff, blockVec3dPos);
             soundType = "mark";
-        } else if (this.detectFluidBlocks && block instanceof FluidBlock && !PlayerUtils.isInFluid()) {
+        } else if (this.detectFluidBlocks && block instanceof FluidBlock && PlayerUtils.isNotInFluid()) {
             FluidState fluidState = minecraftClient.world.getFluidState(blockPos);
             if (fluidState.getLevel() == 8) {
                 fluidBlocks.put(diff, blockVec3dPos);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
@@ -183,9 +183,14 @@ public class POIEntities {
     }
 
     public List<TreeMap<Double, Entity>> getLockingCandidates() {
-        boolean suppressLockingOnNonMarkedThings = onPOIMarkingNow && POIMarkingConfigMap.getInstance().isSuppressOtherWhenEnabled();
-        return suppressLockingOnNonMarkedThings ?
-                List.of(markedEntities) :
-                List.of(markedEntities, hostileEntity, passiveEntity, vehicleEntities);
+        if (onPOIMarkingNow) {
+            if (POIMarkingConfigMap.getInstance().isSuppressOtherWhenEnabled()) {
+                return List.of(markedEntities);
+            } else {
+                return List.of(markedEntities, hostileEntity, passiveEntity, vehicleEntities);
+            }
+        } else {
+            return List.of(hostileEntity, passiveEntity, vehicleEntities);
+        }
     }
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
@@ -14,8 +14,6 @@ import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.mob.WaterCreatureEntity;
 import net.minecraft.entity.passive.PassiveEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.entity.vehicle.BoatEntity;
-import net.minecraft.entity.vehicle.MinecartEntity;
 import net.minecraft.entity.vehicle.VehicleEntity;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;
@@ -138,13 +136,7 @@ public class POIEntities {
                     this.playSoundAtBlockPos(blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 0f);
                 } else if (i instanceof VehicleEntity) {
                     vehicleEntities.put(distance, i);
-                    if (i instanceof MinecartEntity) {
-                        this.playSoundAtBlockPos(blockPos, SoundEvents.ENTITY_MINECART_RIDING, 2f);
-                    } else if (i instanceof BoatEntity) {
-                        this.playSoundAtBlockPos(blockPos, SoundEvents.ENTITY_BOAT_PADDLE_LAND, 2f);
-                    } else {
-                        this.playSoundAtBlockPos(blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 0f);
-                    }
+                    this.playSoundAtBlockPos(blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 0f);
                 }
             }
             log.debug("POIEntities end.");

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
@@ -159,7 +159,7 @@ public class POIEntities {
         this.interval = Interval.inMilliseconds(map.getDelay(), this.interval);
     }
 
-    public void setMarkedEntity(Entity entity) {
+    private void setMarkedEntity(Entity entity) {
         if (entity == null) {
             this.markedEntity = e -> false;
         } else {

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.EyeOfEnderEntity;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.mob.HostileEntity;
 import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.mob.Monster;
 import net.minecraft.entity.mob.WaterCreatureEntity;
 import net.minecraft.entity.passive.PassiveEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -123,7 +124,7 @@ public class POIEntities {
                 if (i instanceof PassiveEntity) {
                     passiveEntity.put(distance, i);
                     this.playSoundAtBlockPos(blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 0f);
-                } else if (i instanceof HostileEntity) {
+                } else if (i instanceof Monster) {
                     hostileEntity.put(distance, i);
                     this.playSoundAtBlockPos(blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 2f);
                 } else if (i instanceof WaterCreatureEntity) {

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
@@ -2,6 +2,7 @@ package com.github.khanshoaib3.minecraft_access.features.point_of_interest;
 
 import com.github.khanshoaib3.minecraft_access.config.config_maps.POIEntitiesConfigMap;
 import com.github.khanshoaib3.minecraft_access.config.config_maps.POIMarkingConfigMap;
+import com.github.khanshoaib3.minecraft_access.utils.WorldUtils;
 import com.github.khanshoaib3.minecraft_access.utils.condition.Interval;
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.client.MinecraftClient;
@@ -13,7 +14,6 @@ import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.mob.WaterCreatureEntity;
 import net.minecraft.entity.passive.PassiveEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.math.BlockPos;
@@ -104,9 +104,9 @@ public class POIEntities {
                 if (this.markedEntity.test(i)) {
                     markedEntities.put(distance, i);
                     if (i instanceof HostileEntity) {
-                        this.playSoundAtBlockPos(minecraftClient, blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 2f);
+                        this.playSoundAtBlockPos(blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 2f);
                     } else {
-                        this.playSoundAtBlockPos(minecraftClient, blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 0f);
+                        this.playSoundAtBlockPos(blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 0f);
                     }
                 }
 
@@ -117,18 +117,18 @@ public class POIEntities {
 
                 if (i instanceof PassiveEntity) {
                     passiveEntity.put(distance, i);
-                    this.playSoundAtBlockPos(minecraftClient, blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 0f);
+                    this.playSoundAtBlockPos(blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 0f);
                 } else if (i instanceof HostileEntity) {
                     hostileEntity.put(distance, i);
-                    this.playSoundAtBlockPos(minecraftClient, blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 2f);
+                    this.playSoundAtBlockPos(blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 2f);
                 } else if (i instanceof WaterCreatureEntity) {
                     passiveEntity.put(distance, i);
-                    this.playSoundAtBlockPos(minecraftClient, blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 0f);
+                    this.playSoundAtBlockPos(blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 0f);
                 } else if (i instanceof ItemEntity itemEntity && itemEntity.isOnGround()) {
-                    this.playSoundAtBlockPos(minecraftClient, blockPos, SoundEvents.BLOCK_METAL_PRESSURE_PLATE_CLICK_ON, 2f);
+                    this.playSoundAtBlockPos(blockPos, SoundEvents.BLOCK_METAL_PRESSURE_PLATE_CLICK_ON, 2f);
                 } else if (i instanceof PlayerEntity) {
                     passiveEntity.put(distance, i);
-                    this.playSoundAtBlockPos(minecraftClient, blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 0f);
+                    this.playSoundAtBlockPos(blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 0f);
                 }
             }
             log.debug("POIEntities end.");
@@ -138,13 +138,10 @@ public class POIEntities {
         }
     }
 
-    private void playSoundAtBlockPos(MinecraftClient minecraftClient, BlockPos blockPos, SoundEvent soundEvent, float pitch) {
-        if (minecraftClient.player == null) return;
-        if (minecraftClient.world == null) return;
-        if (!playSound || !(volume > 0f)) return;
-
-        log.debug("{POIEntity} Playing sound at x:%d y:%d z%d".formatted(blockPos.getX(), blockPos.getY(), blockPos.getZ()));
-        minecraftClient.world.playSound(minecraftClient.player, blockPos, soundEvent, SoundCategory.BLOCKS, volume, pitch);
+    private void playSoundAtBlockPos(BlockPos blockPos, SoundEvent soundEvent, float pitch) {
+        if (!playSound || volume == 0f) return;
+        log.debug("Play sound at [x:%d y:%d z%d]".formatted(blockPos.getX(), blockPos.getY(), blockPos.getZ()));
+        WorldUtils.playSoundAtPosition(soundEvent, volume, pitch, blockPos.toCenterPos());
     }
 
     /**

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
@@ -68,8 +68,9 @@ public class POIEntities {
         loadConfigurations();
     }
 
-    public void update(boolean onMarking) {
+    public void update(boolean onMarking, Entity markedEntity) {
         this.onPOIMarkingNow = onMarking;
+        if (onPOIMarkingNow) setMarkedEntity(markedEntity);
         loadConfigurations();
 
         if (!enabled) return;
@@ -100,7 +101,7 @@ public class POIEntities {
 
                 BlockPos blockPos = i.getBlockPos();
 
-                if (markedEntity.test(i)) {
+                if (this.markedEntity.test(i)) {
                     markedEntities.put(distance, i);
                     if (i instanceof HostileEntity) {
                         this.playSoundAtBlockPos(minecraftClient, blockPos, SoundEvents.BLOCK_NOTE_BLOCK_BELL.value(), 2f);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIMarking.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIMarking.java
@@ -23,7 +23,9 @@ public class POIMarking {
     private static final POIBlocks poiBlocks;
     private static final POIEntities poiEntities;
     private static final LockingHandler lockingHandler;
-    private static boolean onMarking = false;
+    private boolean onMarking = false;
+    private Entity markedEntity = null;
+    private Block markedBlock = null;
 
     static {
         instance = new POIMarking();
@@ -54,8 +56,8 @@ public class POIMarking {
         }
 
         // Trigger other POI features
-        poiBlocks.update(onMarking);
-        poiEntities.update(onMarking);
+        poiBlocks.update(onMarking, markedBlock);
+        poiEntities.update(onMarking, markedEntity);
         // Locking Handler (POI Locking) should be after POI Scan features
         lockingHandler.update(onMarking);
     }
@@ -76,15 +78,14 @@ public class POIMarking {
                 ClientWorld world = client.world;
                 if (world == null) return;
                 BlockPos pos = ((BlockHitResult) hit).getBlockPos();
-                Block b = world.getBlockState(pos).getBlock();
-                poiBlocks.setMarkedBlock(b);
+                markedBlock = world.getBlockState(pos).getBlock();
 
                 String name = NarrationUtils.narrateBlock(pos, "");
                 MainClass.speakWithNarrator(I18n.translate("minecraft_access.point_of_interest.marking.marked", name), true);
             }
             case ENTITY -> {
                 Entity e = ((EntityHitResult) hit).getEntity();
-                poiEntities.setMarkedEntity(e);
+                markedEntity = e;
 
                 String name = NarrationUtils.narrateEntity(e);
                 MainClass.speakWithNarrator(I18n.translate("minecraft_access.point_of_interest.marking.marked", name), true);
@@ -97,8 +98,8 @@ public class POIMarking {
     private void unmark() {
         if (!onMarking) return;
         onMarking = false;
-        poiEntities.setMarkedEntity(null);
-        poiBlocks.setMarkedBlock(null);
+        markedEntity = null;
+        markedBlock = null;
         MainClass.speakWithNarrator(I18n.translate("minecraft_access.point_of_interest.marking.unmarked"), true);
     }
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/NarrationUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/NarrationUtils.java
@@ -207,6 +207,11 @@ public class NarrationUtils {
 
         // Different special narration (toSpeak) about different type of blocks
         try {
+            if (blockState.isOf(Blocks.WATER) || blockState.isOf(Blocks.LAVA)) {
+                toSpeak = NarrationUtils.narrateFluidBlock(blockPos);
+                return new Pair<>(toSpeak, toSpeak);
+            }
+
             if (blockEntity != null) {
                 // The all signs tag include all types of signs, so it should also work with the hanging signs in 1.20.x
                 if (blockState.isIn(BlockTags.ALL_SIGNS)) {
@@ -480,7 +485,7 @@ public class NarrationUtils {
      * "toSpeak" is the actual one to be spoken through Narrator,
      * "currentQuery" is kind of shortened "toSpeak" that is used for checking if target is changed compared to previous.
      */
-    public static String narrateFluidBlock(BlockPos pos) {
+    private static String narrateFluidBlock(BlockPos pos) {
         FluidState fluidState = WorldUtils.getClientWorld().orElseThrow().getFluidState(pos);
         String name = getFluidI18NName(fluidState.getRegistryEntry());
         int level = fluidState.getLevel();

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/NarrationUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/NarrationUtils.java
@@ -31,7 +31,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -193,7 +192,7 @@ public class NarrationUtils {
         // Since Minecraft uses flyweight pattern for blocks and entities,
         // All same type of blocks share one singleton Block instance,
         // While every block keep their states with a BlockState instance.
-        WorldUtils.BlockInfo blockInfo = WorldUtils.getBlockInfo(pos).orElseThrow();
+        WorldUtils.BlockInfo blockInfo = WorldUtils.getBlockInfo(pos);
         BlockPos blockPos = blockInfo.pos();
         BlockState blockState = blockInfo.state();
         Block block = blockInfo.type();
@@ -395,13 +394,11 @@ public class NarrationUtils {
             // If two redstone wires are connected, they're at one of three relative positions: [side, side down, side up].
             // Take one sample relative position (x+1) then check if any block at [-1,0,1] height is also redstone wire.
             Iterable<BlockPos> threePosAtSide = BlockPos.iterate(pos.add(1, -1, 0), pos.add(1, 1, 0));
-            Optional<Boolean> result = WorldUtils.checkAnyOfBlocks(threePosAtSide, IS_REDSTONE_WIRE);
-
-            if (result.isEmpty()) return new Pair<>(toSpeak, currentQuery);
+            boolean result = WorldUtils.checkAnyOfBlocks(threePosAtSide, IS_REDSTONE_WIRE);
             // If there's no redstone wire on x+1 side,
             // then current wire is not connected to that side,
             // so it's not connected to all directions.
-            if (Boolean.FALSE.equals(result.get())) return new Pair<>(toSpeak, currentQuery);
+            if (!result) return new Pair<>(toSpeak, currentQuery);
         }
 
         String directionsToSpeak = String.join(I18n.translate("minecraft_access.other.words_connection"), connectedDirections);
@@ -492,7 +489,7 @@ public class NarrationUtils {
      * "currentQuery" is kind of shortened "toSpeak" that is used for checking if target is changed compared to previous.
      */
     private static String narrateFluidBlock(BlockPos pos) {
-        FluidState fluidState = WorldUtils.getClientWorld().orElseThrow().getFluidState(pos);
+        FluidState fluidState = WorldUtils.getClientWorld().getFluidState(pos);
         String name = getFluidI18NName(fluidState.getRegistryEntry());
         int level = fluidState.getLevel();
         String levelString = level < 8 ? I18n.translate("minecraft_access.read_crosshair.fluid_level", level) : "";

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/NarrationUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/NarrationUtils.java
@@ -19,6 +19,7 @@ import net.minecraft.entity.mob.ZombieVillagerEntity;
 import net.minecraft.entity.passive.*;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.Fluids;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.util.Pair;
@@ -232,7 +233,7 @@ public class NarrationUtils {
             // Check if farmland is wet
             if (block instanceof FarmlandBlock && blockState.get(FarmlandBlock.MOISTURE) == FarmlandBlock.MAX_MOISTURE) {
                 toSpeak = I18n.translate("minecraft_access.crop.wet_farmland", toSpeak);
-                currentQuery = I18n.translate("minecraft_access.crop.wet_farmland", currentQuery);
+                currentQuery = "wet" + currentQuery;
             }
 
             // Speak monster spawner mob type
@@ -252,6 +253,11 @@ public class NarrationUtils {
             Pair<String, String> redstoneRelatedInfo = getRedstoneRelatedInfo(clientWorld, blockPos, block, blockState, toSpeak, currentQuery);
             toSpeak = redstoneRelatedInfo.getLeft();
             currentQuery = redstoneRelatedInfo.getRight();
+
+            if (clientWorld.getFluidState(blockPos).isOf(Fluids.WATER)) {
+                toSpeak = I18n.translate("minecraft_access.crop.water_logged", toSpeak);
+                currentQuery = "waterlogged" + currentQuery;
+            }
 
         } catch (Exception e) {
             log.error("An error occurred while adding narration text for special blocks", e);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/NarrationUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/NarrationUtils.java
@@ -17,6 +17,9 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.mob.HostileEntity;
 import net.minecraft.entity.mob.ZombieVillagerEntity;
 import net.minecraft.entity.passive.*;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.util.Pair;
 import net.minecraft.util.math.BlockPos;
@@ -469,5 +472,27 @@ public class NarrationUtils {
         } else {
             return "minecraft_access.crop.half_ripe";
         }
+    }
+
+    /**
+     * @param pos fluid position (in the client world)
+     * @return (toSpeak, currentQuery):
+     * "toSpeak" is the actual one to be spoken through Narrator,
+     * "currentQuery" is kind of shortened "toSpeak" that is used for checking if target is changed compared to previous.
+     */
+    public static String narrateFluidBlock(BlockPos pos) {
+        FluidState fluidState = WorldUtils.getClientWorld().orElseThrow().getFluidState(pos);
+        String name = getFluidI18NName(fluidState.getRegistryEntry());
+        int level = fluidState.getLevel();
+        String levelString = level < 8 ? I18n.translate("minecraft_access.read_crosshair.fluid_level", level) : "";
+        return name + " " + levelString;
+    }
+
+    private static String getFluidI18NName(RegistryEntry<Fluid> fluid) {
+        String translationKey = fluid.getKeyOrValue().map(
+                (fluidKey) -> "block." + fluidKey.getValue().getNamespace() + "." + fluidKey.getValue().getPath(),
+                (fluidValue) -> "[unregistered " + fluidValue + "]"
+        );
+        return I18n.translate(translationKey);
     }
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerUtils.java
@@ -42,13 +42,13 @@ public class PlayerUtils {
 
     /**
      * Let player looks at entity even the entity exposes a very small part of its body
-     * TODO untested
      */
     public static void lookAt(Entity entity) {
         Vec3d playerEyePos = WorldUtils.getClientPlayer().orElseThrow().getEyePos();
 
         // Try to look at entity's eyes or Enderman's stomach first.
-        Vec3d firstPos = entity instanceof EndermanEntity ? entity.getBlockPos().toCenterPos() : entity.getEyePos();
+        boolean targetIsEnderman = entity instanceof EndermanEntity;
+        Vec3d firstPos = targetIsEnderman ? entity.getBlockPos().toCenterPos() : entity.getEyePos();
         if (isPlayerCanSee(playerEyePos, firstPos, entity)) {
             lookAt(firstPos);
             return;
@@ -68,11 +68,14 @@ public class PlayerUtils {
             return;
         }
 
+        // Never look at Enderman's face
+        double maxY = targetIsEnderman ? MathHelper.lerp(0.7, box.minY, box.maxY) / 2 : box.maxY;
+
         for (double i = 0.0; i <= 1.0; i += stepX) {
             for (double j = 0.0; j <= 1.0; j += stepY) {
                 for (double k = 0.0; k <= 1.0; k += stepZ) {
                     double px = MathHelper.lerp(i, box.minX, box.maxX);
-                    double py = MathHelper.lerp(j, box.minY, box.maxY);
+                    double py = MathHelper.lerp(j, box.minY, maxY);
                     double pz = MathHelper.lerp(k, box.minZ, box.maxZ);
                     Vec3d vec3d = new Vec3d(px + initX, py, pz + initZ);
                     if (isPlayerCanSee(playerEyePos, vec3d, entity)) {

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerUtils.java
@@ -127,8 +127,20 @@ public class PlayerUtils {
     /**
      * The value of MinecraftClient.crosshairTarget field is ray cast result that not including the fluid blocks.
      * So use this method to get what fluid the player might be looking at.
+     *
+     * @return fluid block if player isn't in fluid and is looking at a fluid block,
+     * or MinecraftClient.crosshairTarget otherwise
      */
-    public static BlockHitResult crosshairFluidTarget(double rayCastDistance) {
+    public static HitResult crosshairTarget(double rayCastDistance) {
+        BlockHitResult fluidHitResult = crosshairFluidTarget(rayCastDistance);
+        if (HitResult.Type.BLOCK.equals(fluidHitResult.getType()) && PlayerUtils.isNotInFluid()) {
+            return fluidHitResult;
+        } else {
+            return MinecraftClient.getInstance().crosshairTarget;
+        }
+    }
+
+    private static BlockHitResult crosshairFluidTarget(double rayCastDistance) {
         Entity camera = Objects.requireNonNull(MinecraftClient.getInstance().getCameraEntity());
         HitResult hit = camera.raycast(rayCastDistance, 0.0F, true);
         // Whatever the inner values are, they are not used.

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerUtils.java
@@ -33,18 +33,18 @@ import java.util.Objects;
 public class PlayerUtils {
 
     public static void playSoundOnPlayer(RegistryEntry.Reference<SoundEvent> sound, float volume, float pitch) {
-        WorldUtils.getClientPlayer().orElseThrow().playSound(sound.value(), volume, pitch);
+        WorldUtils.getClientPlayer().playSound(sound.value(), volume, pitch);
     }
 
     public static void lookAt(Vec3d position) {
-        WorldUtils.getClientPlayer().orElseThrow().lookAt(EntityAnchorArgumentType.EntityAnchor.EYES, position);
+        WorldUtils.getClientPlayer().lookAt(EntityAnchorArgumentType.EntityAnchor.EYES, position);
     }
 
     /**
      * Let player looks at entity even the entity exposes a very small part of its body
      */
     public static void lookAt(Entity entity) {
-        Vec3d playerEyePos = WorldUtils.getClientPlayer().orElseThrow().getEyePos();
+        Vec3d playerEyePos = WorldUtils.getClientPlayer().getEyePos();
 
         // Try to look at entity's eyes or Enderman's stomach first.
         boolean targetIsEnderman = entity instanceof EndermanEntity;
@@ -108,18 +108,18 @@ public class PlayerUtils {
     }
 
     public static int getExperienceLevel() {
-        return WorldUtils.getClientPlayer().map(p -> p.experienceLevel).orElse(-999);
+        return WorldUtils.getClientPlayer().experienceLevel;
     }
 
     /**
      * @return percentage-based number
      */
-    public static int getExperienceProgress() {
-        return WorldUtils.getClientPlayer().map(p -> (int) (p.experienceProgress * 100)).orElse(-999);
+    public static float getExperienceProgress() {
+        return WorldUtils.getClientPlayer().experienceProgress * 100;
     }
 
     public static boolean isNotInFluid() {
-        ClientPlayerEntity player = WorldUtils.getClientPlayer().orElseThrow();
+        ClientPlayerEntity player = WorldUtils.getClientPlayer();
         boolean inFluid = player.isSwimming()
                 || player.isSubmergedInWater()
                 || player.isInsideWaterOrBubbleColumn()
@@ -152,7 +152,7 @@ public class PlayerUtils {
         if (!HitResult.Type.BLOCK.equals(hit.getType())) return missed;
 
         BlockPos blockPos = ((BlockHitResult) hit).getBlockPos();
-        ClientWorld world = WorldUtils.getClientWorld().orElseThrow();
+        ClientWorld world = WorldUtils.getClientWorld();
 
         BlockState blockState = world.getBlockState(blockPos);
         boolean thisBlockIsFluidBlock = blockState.isOf(Blocks.WATER) || blockState.isOf(Blocks.LAVA);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerUtils.java
@@ -5,11 +5,17 @@ import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.command.argument.EntityAnchorArgumentType;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.mob.EndermanEntity;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.sound.SoundEvent;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.RaycastContext;
 import net.minecraft.world.World;
 
 /**
@@ -31,10 +37,59 @@ public class PlayerUtils {
         WorldUtils.getClientPlayer().orElseThrow().lookAt(EntityAnchorArgumentType.EntityAnchor.EYES, position);
     }
 
+    /**
+     * Let player looks at entity even the entity exposes a very small part of its body
+     * TODO untested
+     */
     public static void lookAt(Entity entity) {
-        double aboutEntityHeadHeight = entity.getY() + entity.getHeight() - 0.25;
-        Vec3d aboutEntityHeadPosition = new Vec3d(entity.getX(), aboutEntityHeadHeight, entity.getZ());
-        lookAt(aboutEntityHeadPosition);
+        Vec3d playerEyePos = WorldUtils.getClientPlayer().orElseThrow().getEyePos();
+
+        // Try to look at entity's eyes or Enderman's stomach first.
+        Vec3d firstPos = entity instanceof EndermanEntity ? entity.getBlockPos().toCenterPos() : entity.getEyePos();
+        if (isPlayerCanSee(playerEyePos, firstPos, entity)) {
+            lookAt(firstPos);
+            return;
+        }
+
+        // Then start to find a possible position to target at the entity.
+        // This part of code is copied from Explosion.getExposure()
+        Box box = entity.getBoundingBox();
+        double stepX = 1.0 / ((box.maxX - box.minX) * 2.0 + 1.0);
+        double stepY = 1.0 / ((box.maxY - box.minY) * 2.0 + 1.0);
+        double stepZ = 1.0 / ((box.maxZ - box.minZ) * 2.0 + 1.0);
+        // Don't know how these two lengths are determined
+        double initX = (1.0 - Math.floor(1.0 / stepX) * stepX) / 2.0;
+        double initZ = (1.0 - Math.floor(1.0 / stepZ) * stepZ) / 2.0;
+        if (stepX < 0.0 || stepY < 0.0 || stepZ < 0.0) {
+            lookAt(firstPos);
+            return;
+        }
+
+        for (double i = 0.0; i <= 1.0; i += stepX) {
+            for (double j = 0.0; j <= 1.0; j += stepY) {
+                for (double k = 0.0; k <= 1.0; k += stepZ) {
+                    double px = MathHelper.lerp(i, box.minX, box.maxX);
+                    double py = MathHelper.lerp(j, box.minY, box.maxY);
+                    double pz = MathHelper.lerp(k, box.minZ, box.maxZ);
+                    Vec3d vec3d = new Vec3d(px + initX, py, pz + initZ);
+                    if (isPlayerCanSee(playerEyePos, vec3d, entity)) {
+                        lookAt(vec3d);
+                        return;
+                    }
+                }
+            }
+        }
+
+        // Make sure to look at entity even the player can't see it.
+        lookAt(firstPos);
+    }
+
+    private static boolean isPlayerCanSee(Vec3d playerEyePos, Vec3d somewhereOnEntity, Entity entity) {
+        BlockHitResult hitResult = entity.getWorld().raycast(
+                new RaycastContext(somewhereOnEntity, playerEyePos,
+                        RaycastContext.ShapeType.COLLIDER,
+                        RaycastContext.FluidHandling.NONE, entity));
+        return hitResult.getType() == HitResult.Type.MISS;
     }
 
     @SuppressWarnings("unused")

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerUtils.java
@@ -115,12 +115,13 @@ public class PlayerUtils {
         return WorldUtils.getClientPlayer().map(p -> (int) (p.experienceProgress * 100)).orElse(-999);
     }
 
-    public static boolean isInFluid() {
+    public static boolean isNotInFluid() {
         ClientPlayerEntity player = WorldUtils.getClientPlayer().orElseThrow();
-        return player.isSwimming()
+        boolean inFluid = player.isSwimming()
                 || player.isSubmergedInWater()
                 || player.isInsideWaterOrBubbleColumn()
                 || player.isInLava();
+        return !inFluid;
     }
 
     /**

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/WorldUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/WorldUtils.java
@@ -13,17 +13,14 @@ import net.minecraft.sound.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 
-import java.util.Optional;
 import java.util.function.Predicate;
 
 public class WorldUtils {
     public record BlockInfo(BlockPos pos, BlockState state, Block type, BlockEntity entity) {
     }
 
-    public static Optional<BlockInfo> getBlockInfo(BlockPos pos) {
-        Optional<ClientWorld> w = getClientWorld();
-        if (w.isEmpty()) return Optional.empty();
-        ClientWorld world = w.get();
+    public static BlockInfo getBlockInfo(BlockPos pos) {
+        ClientWorld world = getClientWorld();
 
         // Since Minecraft uses flyweight pattern for blocks and entities,
         // All same type of blocks share one singleton Block instance,
@@ -32,31 +29,24 @@ public class WorldUtils {
         Block block = state.getBlock();
         BlockEntity entity = world.getBlockEntity(pos);
 
-        return Optional.of(new BlockInfo(pos, state, block, entity));
+        return new BlockInfo(pos, state, block, entity);
     }
 
-    public static Optional<ClientWorld> getClientWorld() {
-        MinecraftClient c = MinecraftClient.getInstance();
-        if (c == null) return Optional.empty();
-        ClientWorld world = c.world;
-        return world == null ? Optional.empty() : Optional.of(world);
+    public static ClientWorld getClientWorld() {
+        return MinecraftClient.getInstance().world;
     }
 
-    public static Optional<ClientPlayerEntity> getClientPlayer() {
-        MinecraftClient c = MinecraftClient.getInstance();
-        if (c == null) return Optional.empty();
-        ClientPlayerEntity p = c.player;
-        return p == null ? Optional.empty() : Optional.of(p);
+    public static ClientPlayerEntity getClientPlayer() {
+        return MinecraftClient.getInstance().player;
     }
 
-    public static Optional<Boolean> checkAnyOfBlocks(Iterable<BlockPos> positions, Predicate<BlockState> expected) {
+    public static boolean checkAnyOfBlocks(Iterable<BlockPos> positions, Predicate<BlockState> expected) {
         for (BlockPos pos : positions) {
-            Optional<BlockInfo> info = getBlockInfo(pos);
-            if (info.isEmpty()) return Optional.empty();
-
-            if (expected.test(info.get().state)) return Optional.of(true);
+            BlockInfo info = getBlockInfo(pos);
+            if (info.state == null) return false;
+            if (expected.test(info.state)) return true;
         }
-        return Optional.of(false);
+        return false;
     }
 
     /**
@@ -85,6 +75,6 @@ public class WorldUtils {
 
     public static void playSoundAtPosition(RegistryEntry.Reference<SoundEvent> sound, float volume, float pitch, Vec3d position) {
         // note that the useDistance param only works for positions 100 blocks away, check its code.
-        getClientWorld().orElseThrow().playSound(position.x, position.y, position.z, sound.value(), SoundCategory.BLOCKS, volume, pitch, true);
+        getClientWorld().playSound(position.x, position.y, position.z, sound.value(), SoundCategory.BLOCKS, volume, pitch, true);
     }
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/WorldUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/WorldUtils.java
@@ -74,7 +74,11 @@ public class WorldUtils {
     }
 
     public static void playSoundAtPosition(RegistryEntry.Reference<SoundEvent> sound, float volume, float pitch, Vec3d position) {
+        playSoundAtPosition(sound.value(), volume, pitch, position);
+    }
+
+    public static void playSoundAtPosition(SoundEvent sound, float volume, float pitch, Vec3d position) {
         // note that the useDistance param only works for positions 100 blocks away, check its code.
-        getClientWorld().playSound(position.x, position.y, position.z, sound.value(), SoundCategory.BLOCKS, volume, pitch, true);
+        getClientWorld().playSound(position.x, position.y, position.z, sound, SoundCategory.BLOCKS, volume, pitch, true);
     }
 }

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -3,11 +3,13 @@ Release v1.5.3 (2024-02)
 
 ### Feature Changes
 
-* Now the Read Crosshair will only play the position sound cue once when player looks at different sides of same block.
+* Now the Read Crosshair feature will only play the position sound cue once when player looks at different sides of same block.
+* When locking on an entity, POI Locking feature will always try to target at a valid position that you can interact with, instead of previous "always targeting on head" behavior.
+* Now POI Locking feature will never let you make eye contact with an [Enderman](https://minecraft.wiki/w/Enderman).
 
 ### Bug Fixes
 
-* Fix the bug that looking at fluid will make Read Crosshair spam [#262](https://github.com/khanshoaib3/minecraft_access/issues/262)
+* Fix the bug that looking at fluid will make Read Crosshair spam. [#262](https://github.com/khanshoaib3/minecraft_access/issues/262)
 
 Release v1.5.2 (2024-01)
 ---------------------------

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,9 +4,9 @@ Release v1.5.3 (2024-02)
 ### Feature Changes
 
 * Now the Read Crosshair feature will only play the position sound cue once when player looks at different sides of same block.
-* When locking on an entity, POI Locking feature will always try to target at a valid position that you can interact with, instead of previous "always targeting on head" behavior.
+* When locking on an entity, POI Locking feature will always try to target at a valid position that you can interact with, thus you can attack a monster even it expose small part of its body to you.
 * Now POI Locking feature will never let you make eye contact with an [Enderman](https://minecraft.wiki/w/Enderman).
-* Boats, mine carts, and ancient debris blocks can be scanned and locked with POI feature now. [#157](https://github.com/khanshoaib3/minecraft_access/issues/157) [#215](https://github.com/khanshoaib3/minecraft_access/issues/215)
+* [Boat](https://minecraft.wiki/w/Boat), [mine cart](https://minecraft.wiki/w/Minecart), [slime](https://minecraft.wiki/w/Slime), [magma cube](https://minecraft.wiki/w/Magma_cube], and [ancient debris](https://minecraft.wiki/w/Ancient_debris) can be scanned and locked with POI feature now. [#157](https://github.com/khanshoaib3/minecraft_access/issues/157) [#203](https://github.com/khanshoaib3/minecraft_access/issues/203) [#215](https://github.com/khanshoaib3/minecraft_access/issues/215)
 
 ### Bug Fixes
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@ Release v1.5.3 (2024-02)
 * Now the Read Crosshair feature will only play the position sound cue once when player looks at different sides of same block.
 * When locking on an entity, POI Locking feature will always try to target at a valid position that you can interact with, instead of previous "always targeting on head" behavior.
 * Now POI Locking feature will never let you make eye contact with an [Enderman](https://minecraft.wiki/w/Enderman).
+* Boats and mine carts can be scanned and locked with POI feature now. [#157](https://github.com/khanshoaib3/minecraft_access/issues/157)
 
 ### Bug Fixes
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release v1.5.3 (2024-02)
+---------------------------
+
+### Bug Fixes
+
+* Fix the bug that looking at fluid will make Read Crosshair spam [#262](https://github.com/khanshoaib3/minecraft_access/issues/262)
+
 Release v1.5.2 (2024-01)
 ---------------------------
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,7 +6,7 @@ Release v1.5.3 (2024-02)
 * Now the Read Crosshair feature will only play the position sound cue once when player looks at different sides of same block.
 * When locking on an entity, POI Locking feature will always try to target at a valid position that you can interact with, instead of previous "always targeting on head" behavior.
 * Now POI Locking feature will never let you make eye contact with an [Enderman](https://minecraft.wiki/w/Enderman).
-* Boats and mine carts can be scanned and locked with POI feature now. [#157](https://github.com/khanshoaib3/minecraft_access/issues/157)
+* Boats, mine carts, and ancient debris blocks can be scanned and locked with POI feature now. [#157](https://github.com/khanshoaib3/minecraft_access/issues/157) [#215](https://github.com/khanshoaib3/minecraft_access/issues/215)
 
 ### Bug Fixes
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,6 +1,10 @@
 Release v1.5.3 (2024-02)
 ---------------------------
 
+### Feature Changes
+
+* Now the Read Crosshair will only play the position sound cue once when player looks at different sides of same block.
+
 ### Bug Fixes
 
 * Fix the bug that looking at fluid will make Read Crosshair spam [#262](https://github.com/khanshoaib3/minecraft_access/issues/262)

--- a/doc/KEYBINDINGS.md
+++ b/doc/KEYBINDINGS.md
@@ -40,7 +40,7 @@ You may want to take a look at [all the original controls](https://minecraft.wik
 | `Center Camera Key`          | Number Pad 5       | Look straight ahead: Turn the camera to the closest of the eight cardinal directions and reset vertical angle to horizontal position |
 | `Look Straight Up Key`       | Number Pad 0       | Turn the camera to the look above head direction                                                                                     |
 | `Look Straight Down Key`     | Number Pad .       | Turn the camera to the look down at feet direction                                                                                   |
-| `Speak Facing Direction Key` | H                  | Speak the currently facing direction                                                                                                 |
+| `Speak Facing Direction Key` | H                  | Speak current horizontal facing direction                                                                                            |
 
 | Key Combination                                                           | Description                                                                                                                                         |
 |---------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -53,6 +53,7 @@ You may want to take a look at [all the original controls](https://minecraft.wik
 | `Right Alt` + `Look Right Key`                                            | Same as single `Look East Key`, turn the camera to the east                                                                                         |
 | hold `Right Alt` then press `Look Down Key`                               | Same as single `Look South Key` and single `Look Straight Down Key`, alternately move the camera to the south or down                               |
 | `Right Alt` + `Look Left Key`                                             | Same as single `Look West Key`, turn the camera to the west                                                                                         |
+| `Left Alt` + `Speak Facing Direction Key`                                 | Speak current vertical facing direction                                                                                                             |
 
 See also: [Feature Description](/doc/FEATURES.md#camera-controls), [Configuration](/doc/CONFIG.md#camera-controls)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ fabric_yarn_version=1.20.4+build.1:v2
 enabled_platforms=fabric,forge
 
 archives_base_name=minecraft-access
-mod_version=1.5.2+1.20.4
+mod_version=1.5.3+1.20.4
 maven_group=com.github.khanshoaib3.minecraft_access
 
 # https://maven.architectury.dev/dev/architectury/


### PR DESCRIPTION
## Pull Request Checklist

[//]: # (Use `~~ -[ ] ... ~~` markdown deletion syntax to cross out unrelated entries)

~~- [ ] A new fragment is added in `./doc/news` that describes what is new (refer to issue #174).~~

## Describe what you have changed in this PR

### Feature Changes

* Now the Read Crosshair feature will only play the position sound cue once when player looks at different sides of same block.
* When locking on an entity, POI Locking feature will always try to target at a valid position that you can interact with, thus you can attack a monster even it expose small part of its body to you.
* Now POI Locking feature will never let you make eye contact with an [Enderman](https://minecraft.wiki/w/Enderman).
* Boat, mine cart, slime, magma cube, and ancient debris can be scanned and locked with POI feature now. [#157](https://github.com/khanshoaib3/minecraft_access/issues/157) [#203](https://github.com/khanshoaib3/minecraft_access/issues/203) [#215](https://github.com/khanshoaib3/minecraft_access/issues/215)

### Bug Fixes

* Fix the bug that looking at fluid will make Read Crosshair spam. [#262](https://github.com/khanshoaib3/minecraft_access/issues/262)

And some refactor.
With https://github.com/khanshoaib3/minecraft-access-i18n/pull/32

Will release these changes as `1.5.3`.