### PR TITLE
fix: force getting lombok jar from maven central

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,3 +1,17 @@
+repositories {
+    mavenCentral()
+    // Make sure getting lombok jar from maven central (instead of forge repo or so)
+    // ref: https://discuss.gradle.org/t/how-to-make-gradle-stop-getting-a-not-existing-jar-from-a-third-party-maven-repo/48290/4
+    exclusiveContent {
+        forRepository {
+            mavenCentral()
+        }
+        filter {
+            includeGroup "org.projectlombok"
+        }
+    }
+}
+
 architectury {
     common(rootProject.enabled_platforms.split(","))
 }
@@ -15,10 +29,7 @@ dependencies {
 
     // lombok that makes the life easier
     // https://projectlombok.org/setup/gradle
-    compileOnly 'org.projectlombok:lombok:1.18.30'
-    annotationProcessor 'org.projectlombok:lombok:1.18.30'
-    testCompileOnly 'org.projectlombok:lombok:1.18.30'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
+    compileOnly group: "org.projectlombok", name: "lombok", version: "1.18.30"
 
     // dependent on log4j for dynamic changing
     implementation 'org.apache.logging.log4j:log4j-api:2.22.1'


### PR DESCRIPTION
forge maven repo cause read time out error during gradle build

## Pull Request Checklist

[//]: # (Use `~~ -[ ] ... ~~` markdown deletion syntax to cross out unrelated entries)

~~- [ ] A new fragment is added in `./doc/news` that describes what is new (refer to issue #174).~~

## Describe what you have changed in this PR

See commit messages.