### PR TITLE
Fix 1.20.6 forge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     // ref: https://maven.architectury.dev/dev/architectury/architectury-loom/
     // Loom 1.6: "Developers should use Loom 1.6 (at the time of writing) to develop mods for Minecraft 1.20.5."
     // ref: https://fabricmc.net/2024/04/19/1205.html
-    id "dev.architectury.loom" version "1.6-SNAPSHOT" apply false
+    id "dev.architectury.loom" version "1.7-SNAPSHOT" apply false
 }
 
 architectury {

--- a/common/src/main/resources/minecraft_access-common.mixins.json
+++ b/common/src/main/resources/minecraft_access-common.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.github.khanshoaib3.minecraft_access.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "AnimatedResultButtonAccessor",
     "AnimatedResultButtonMixin",

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,11 @@ Release v1.6.1 (2024-06)
 
 - New guide page: [Good Resources](/doc/GOOD_RESOURCES.md)
 - Remove `fabric-api` dependence for Fabric
+- forge_version: `1.20.6-50.0.0` -> `1.20.6-50.1.0`
+- architectury_loom_version: `1.6-SNAPSHOT` -> `1.7-SNAPSHOT`
+- grade: `8.6` -> `8.8` (required by loom 1.7)
+- fabric_yarn_version: `1.20.6+build.1:v2` -> `1.20.6+build.3:v2`
+- Add mixin dependency `io.github.llamalad7:mixinextras:0.4.0` for forge
 
 Release v1.6.0 (2024-06)
 ---------------------------
@@ -30,6 +35,10 @@ Release v1.6.0 (2024-06)
 ### Others
 
 - Remove `architectury-api` dependence
+- minecraft_version: `1.20.4` -> `1.20.6`
+- forge_version: `1.20.4-49.0.19` -> `1.20.6-50.0.31`
+- architectury_loom_version: `1.4-SNAPSHOT` -> `1.6-SNAPSHOT`
+- fabric_loader_version: `0.15.1` -> `0.15.11`
 
 ### Development Chores
 
@@ -52,16 +61,6 @@ Release v1.5.3 (2024-02)
 * When locking on an entity, POI Locking feature will always try to target at a valid position that you can interact with, thus you can attack a monster even it expose small part of its body to you.
 * Now POI Locking feature will never let you make eye contact with an [Enderman](https://minecraft.wiki/w/Enderman).
 * [Boat](https://minecraft.wiki/w/Boat), [mine cart](https://minecraft.wiki/w/Minecart), [slime](https://minecraft.wiki/w/Slime), [magma cube](https://minecraft.wiki/w/Magma_cube), and [ancient debris](https://minecraft.wiki/w/Ancient_debris) can be scanned and locked with POI feature now. [#157](https://github.com/khanshoaib3/minecraft_access/issues/157) [#203](https://github.com/khanshoaib3/minecraft_access/issues/203) [#215](https://github.com/khanshoaib3/minecraft_access/issues/215)
-
-- aoNIWDn
-- aOINDWo21
-- aOINDWo21
-
-### Feature Updates
-
-- AONO@Nlkdn21lk
-- aoNIWDn
-- AONO@Nlkdn21lk
 
 ### Bug Fixes
 

--- a/doc/MOD_COMPATIBILITY.md
+++ b/doc/MOD_COMPATIBILITY.md
@@ -4,7 +4,7 @@ Compatibility For 1.20.6
 * Minecraft: 1.20.6 ([read setup guide](/doc/SET_UP.md))
 * Java: >=21 ([download x64 Windows installer](https://download.oracle.com/java/21/latest/jdk-21_windows-x64_bin.msi), [download page for all Operating Systems](https://www.oracle.com/java/technologies/downloads/#java21))
 * Fabric Loader: >=0.15.11 ([download Fabric Loader](https://fabricmc.net/use/installer/))
-* Forge: 1.20.6-50.0.* ([download Forge installer](https://maven.minecraftforge.net/net/minecraftforge/forge/1.20.6-50.0.31/forge-1.20.6-50.0.31-installer.jar))
+* Forge: 1.20.6-50.1.0 ([download Forge installer](https://maven.minecraftforge.net/net/minecraftforge/forge/1.20.6-50.1.0/forge-1.20.6-50.1.0-installer.jar))
 
 Compatibility For 1.20.4
 ---------------------------

--- a/doc/changelogs/latest.md
+++ b/doc/changelogs/latest.md
@@ -17,3 +17,5 @@
 - Update good resource page to include TrueBlindGaming tutorial videos, update beginner guide
 
 ### Development Chores
+
+- 

--- a/fabric/src/main/resources/minecraft_access.mixins.json
+++ b/fabric/src/main/resources/minecraft_access.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.github.khanshoaib3.minecraft_access.fabric.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
   ],
   "client": [

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -50,6 +50,13 @@ dependencies {
 
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionForge")) { transitive = false }
+
+    // https://github.com/LlamaLad7/MixinExtras
+    // fabric has this dependency,
+    // we already used this dependency in common module,
+    // so let forge use it too
+    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.0"))
+    implementation(include("io.github.llamalad7:mixinextras-forge:0.4.0"))
 }
 
 processResources {
@@ -68,14 +75,7 @@ shadowJar {
     archiveClassifier = "dev-shadow"
 }
 
-remapJar {
-    // since 1.20.6
-    enabled false
-    //noinspection GrDeprecatedAPIUsage
-    input.set shadowJar.archiveFile
-    dependsOn shadowJar
-    archiveClassifier = null
-}
+// Forge doesn't need remap since 1.20.6
 
 jar {
     archiveClassifier = "dev"

--- a/forge/src/main/resources/minecraft_access.mixins.json
+++ b/forge/src/main/resources/minecraft_access.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.github.khanshoaib3.minecraft_access.forge.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
   ],
   "client": [

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ minecraft_version=1.20.6
 # when upgrading the yarn version:
 # ref: https://fabricmc.net/wiki/tutorial:migratemappings
 #      https://fabricmc.net/develop/
-fabric_yarn_version=1.20.6+build.1:v2
+fabric_yarn_version=1.20.6+build.3:v2
 
 enabled_platforms=fabric,forge
 
@@ -27,8 +27,8 @@ fabric_loader_version=0.15.11
 # https://fabricmc.net/develop/
 # then search corresponding pom file of that api version:
 # https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api/
-# then get resource loader version from pom file
+# then get fabric-resource-loader-v0 version from pom file
 fabric_resource_loader_version=1.1.0+c0e5481fb0
 
 # https://files.minecraftforge.net/net/minecraftforge/forge/
-forge_version=50.0.31
+forge_version=50.1.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Changelog (already written in doc):

- forge_version: `1.20.6-50.0.0` -> `1.20.6-50.1.0`
- architectury_loom_version: `1.6-SNAPSHOT` -> `1.7-SNAPSHOT`
- grade: `8.6` -> `8.8` (required by loom 1.7)
- fabric_yarn_version: `1.20.6+build.1:v2` -> `1.20.6+build.3:v2`
- Add mixin dependency `io.github.llamalad7:mixinextras:0.4.0` for forge

will try to run formal release workflow (v1.6.1+1.20.6) after merging, to push mod onto platforms.