### PR TITLE
build: stop using GITHUB_TOKEN in fast-forward workflow

### DIFF
--- a/.github/workflows/fast_forward.yml
+++ b/.github/workflows/fast_forward.yml
@@ -21,33 +21,36 @@ jobs:
       !github.event.issue.closed_at &&
       github.event.issue.state == 'open' &&
       (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR') && 
-      contains(github.event.comment.body, '/fast-forward')
+      (contains(github.event.comment.body, '/fast-forward') || contains(github.event.comment.body, '/ff'))
 
     steps:
       - name: Fetch repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
 
-      # API: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
+      # action: https://github.com/actions/github-script
+      # API: https://octokit.github.io/rest.js/v21/#pulls-get
       - name: Get PR details
-        uses: octokit/request-action@v2.x
+        uses: actions/github-script@v7
         id: get-pr-details
         with:
-          route: GET /repos/{repository}/pulls/{pull_number}
-          repository: ${{ github.repository }}
-          pull_number: ${{ github.event.issue.number }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          retries: 3
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            })
+            return pr.data
 
       - name: Set environment variables
         run: |
-          MERGE_STATUS=${{ fromJson(steps.get-pr-details.outputs.data).mergeable }}
+          MERGE_STATUS=${{ fromJson(steps.get-pr-details.outputs.result).mergeable }}
           if $MERGE_STATUS; then echo "COMMENT=\[Fast Forward CI\] ${{ env.HEAD_REF }} cannot be merged into ${{ env.BASE_REF }} at the moment." >> $GITHUB_ENV; fi
           echo "MERGE_STATUS=$MERGE_STATUS" >> $GITHUB_ENV
-          echo "BASE_REF=${{ fromJson(steps.get-pr-details.outputs.data).base.ref }}" >> $GITHUB_ENV
-          echo "HEAD_REF=${{ fromJson(steps.get-pr-details.outputs.data).head.ref }}" >> $GITHUB_ENV
+          echo "BASE_REF=${{ fromJson(steps.get-pr-details.outputs.result).base.ref }}" >> $GITHUB_ENV
+          echo "HEAD_REF=${{ fromJson(steps.get-pr-details.outputs.result).head.ref }}" >> $GITHUB_ENV
 
       # Merges the head branch into base branch
       # Only runs if the merge status is "clean", clean might refer to when the merge button is green in the PR's page, there's no clear indication of it's values in docs
@@ -59,9 +62,9 @@ jobs:
           git config --global user.name "GitHub Action"
           git checkout ${{ env.BASE_REF }}
           git pull origin ${{ env.BASE_REF }}
-          if ${{ fromJson(steps.get-pr-details.outputs.data).head.repo.fork }}; then
-            USER_NAME=${{ fromJson(steps.get-pr-details.outputs.data).head.user.login }}
-            git remote add $USER_NAME ${{ fromJson(steps.get-pr-details.outputs.data).head.repo.clone_url }}
+          if ${{ fromJson(steps.get-pr-details.outputs.result).head.repo.fork }}; then
+            USER_NAME=${{ fromJson(steps.get-pr-details.outputs.result).head.user.login }}
+            git remote add $USER_NAME ${{ fromJson(steps.get-pr-details.outputs.result).head.repo.clone_url }}
             git pull $USER_NAME ${{ env.HEAD_REF }}
             git merge --ff-only $USER_NAME/${{ env.HEAD_REF }}
           else
@@ -104,24 +107,27 @@ jobs:
           echo "COMMENT=${{ env.COMMENT }} Pushed the changes to origin." >> $GITHUB_ENV
 
       # Post a success/failure comment to the PR.
+      # API: https://github.com/actions/github-script?tab=readme-ov-file#comment-on-an-issue
       - name: Add success/failure comment to PR
-        uses: octokit/request-action@v2.x
+        uses: actions/github-script@v7
         with:
-          route: POST /repos/{repository}/issues/{issue_number}/comments
-          repository: ${{ github.repository }}
-          issue_number: ${{ github.event.issue.number }}
-          body: ${{ env.COMMENT }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '${{ env.COMMENT }}'
+            })
 
       # Post a failure message when any of the previous steps fail.
       - name: Add failure comment to PR
         if: ${{ failure() }}
-        uses: octokit/request-action@v2.x
+        uses: actions/github-script@v7
         with:
-          route: POST /repos/{repository}/issues/{issue_number}/comments
-          repository: ${{ github.repository }}
-          issue_number: ${{ github.event.issue.number }}
-          body: \[Fast Forward CI\] PR cannot be merged in. Check the Actions tab for details.
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '\[Fast Forward CI\] PR cannot be merged in. Check the Actions tab for details.'
+            })

--- a/.github/workflows/fast_forward.yml
+++ b/.github/workflows/fast_forward.yml
@@ -24,10 +24,12 @@ jobs:
       (contains(github.event.comment.body, '/fast-forward') || contains(github.event.comment.body, '/ff'))
 
     steps:
-      - name: Fetch repository
+      # Fine-grained PAT with contents:write and workflows:write scopes
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.WORKFLOW_TOKEN }}
 
       # action: https://github.com/actions/github-script
       # API: https://octokit.github.io/rest.js/v21/#pulls-get


### PR DESCRIPTION
## Changelog

### Development Chores

- Stop using GITHUB_TOKEN in `fast_forward` workflow