### PR TITLE
Add basic aim assist for bows

### DIFF
--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/POILockingConfigMap.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/POILockingConfigMap.java
@@ -26,6 +26,10 @@ public class POILockingConfigMap {
     private int delay;
     @SerializedName("Bow aim assist")
     private boolean aimAssistEnabled;
+    @SerializedName("Aim assist audio cues")
+    private boolean aimAssistAudioCuesEnabled;
+    @SerializedName("Aim assist audio cues volume")
+    private float aimAssistAudioCuesVolume;
 
     private POILockingConfigMap() {
     }
@@ -44,6 +48,8 @@ public class POILockingConfigMap {
         m.setAutoLockEyeOfEnderEntity(true);
         m.setDelay(100);
         m.setAimAssistEnabled(true);
+        m.setAimAssistAudioCuesEnabled(true);
+        m.setAimAssistAudioCuesVolume(0.5f);
 
         setInstance(m);
         return m;

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/POILockingConfigMap.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_maps/POILockingConfigMap.java
@@ -24,6 +24,8 @@ public class POILockingConfigMap {
     private boolean autoLockEyeOfEnderEntity;
     @SerializedName("Delay (in milliseconds)")
     private int delay;
+    @SerializedName("Bow aim assist")
+    private boolean aimAssistEnabled;
 
     private POILockingConfigMap() {
     }
@@ -41,6 +43,7 @@ public class POILockingConfigMap {
         m.setUnlockingSound(false);
         m.setAutoLockEyeOfEnderEntity(true);
         m.setDelay(100);
+        m.setAimAssistEnabled(true);
 
         setInstance(m);
         return m;

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_menus/POIConfigMenu.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_menus/POIConfigMenu.java
@@ -267,6 +267,20 @@ class POILockingConfigMenu extends BaseScreen {
                 I18n.translate("minecraft_access.gui.common.button.delay", initMap.getDelay()),
                 (button) -> this.client.setScreen(new ValueEntryMenu(c1, this)));
         this.addDrawableChild(delayButton);
+
+        ButtonWidget aimAssistButton = this.buildButtonWidget(
+                I18n.translate("minecraft_access.gui.common.button.toggle_button." + (initMap.isAimAssistEnabled() ? "enabled" : "disabled"),
+                        I18n.translate("minecraft_access.gui.poi_locking_config_menu.button.aim_assist_button")
+                ),
+                (button) -> {
+                    POILockingConfigMap map = POILockingConfigMap.getInstance();
+                    map.setAimAssistEnabled(!map.isAimAssistEnabled());
+                    Config.getInstance().writeJSON();
+                    button.setMessage(Text.of(I18n.translate("minecraft_access.gui.common.button.toggle_button." + (map.isAimAssistEnabled() ? "enabled" : "disabled"),
+                            I18n.translate("minecraft_access.gui.poi_locking_config_menu.button.aim_assist_button")
+                    )));
+                });
+        this.addDrawableChild(aimAssistButton);
     }
 }
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_menus/POIConfigMenu.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/config/config_menus/POIConfigMenu.java
@@ -281,6 +281,31 @@ class POILockingConfigMenu extends BaseScreen {
                     )));
                 });
         this.addDrawableChild(aimAssistButton);
+
+                ButtonWidget aimAssistAudioCuesButton = this.buildButtonWidget(
+                        I18n.translate("minecraft_access.gui.common.button.toggle_button." + (initMap.isAimAssistAudioCuesEnabled() ? "enabled" : "disabled"),
+                                I18n.translate("minecraft_access.gui.poi_locking_config_menu.button.aim_assist_audio_cues_button")
+                        ),
+                        (button) -> {
+                            POILockingConfigMap map = POILockingConfigMap.getInstance();
+                            map.setAimAssistAudioCuesEnabled(!map.isAimAssistAudioCuesEnabled());
+                            Config.getInstance().writeJSON();
+                            button.setMessage(Text.of(I18n.translate("minecraft_access.gui.common.button.toggle_button." + (map.isAimAssistAudioCuesEnabled() ? "enabled" : "disabled"),
+                                    I18n.translate("minecraft_access.gui.poi_locking_config_menu.button.aim_assist_audio_cues_button")
+                            )));
+                        });
+                this.addDrawableChild(aimAssistAudioCuesButton);
+
+                ValueEntryMenu.ValueConfig aimAssistAudioCuesVolumeConfig = new ValueEntryMenu.ValueConfig(
+                        () -> POILockingConfigMap.getInstance().getAimAssistAudioCuesVolume(),
+                        (v) -> POILockingConfigMap.getInstance().setAimAssistAudioCuesVolume(Float.parseFloat(v)),
+                        ValueEntryMenu.ValueType.FLOAT
+                );
+                ButtonWidget aimAssistAudioCuesVolumeButton = this.buildButtonWidget(
+                        I18n.translate("minecraft_access.gui.poi_locking_config_menu.button.aim_assist_audio_cues_volume", initMap.getAimAssistAudioCuesVolume()),
+                        (button) -> this.client.setScreen(new ValueEntryMenu(aimAssistAudioCuesVolumeConfig, this))
+                );
+                this.addDrawableChild(aimAssistAudioCuesVolumeButton);
     }
 }
 

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/POIEntities.java
@@ -165,4 +165,8 @@ public class POIEntities {
             return List.of(hostileEntity, passiveEntity, vehicleEntities);
         }
     }
+
+    public TreeMap<Double, Entity> getAimAssistTargetCandidates() {
+        return hostileEntity;
+    }
 }

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/PlayerUtils.java
@@ -31,6 +31,8 @@ import java.util.Objects;
  * Forgive me for doing this, but it's the most economical way.)
  */
 public class PlayerUtils {
+    // A way to get exactly at what part of the entity the player is looking when locked on it
+    public static Vec3d currentEntityLookingAtPosition = null;
 
     public static void playSoundOnPlayer(RegistryEntry.Reference<SoundEvent> sound, float volume, float pitch) {
         WorldUtils.getClientPlayer().playSound(sound.value(), volume, pitch);
@@ -51,6 +53,7 @@ public class PlayerUtils {
         Vec3d firstPos = targetIsEnderman ? entity.getBlockPos().toCenterPos() : entity.getEyePos();
         if (isPlayerCanSee(playerEyePos, firstPos, entity)) {
             lookAt(firstPos);
+            currentEntityLookingAtPosition = firstPos;
             return;
         }
 
@@ -65,6 +68,7 @@ public class PlayerUtils {
         double initZ = (1.0 - Math.floor(1.0 / stepZ) * stepZ) / 2.0;
         if (stepX < 0.0 || stepY < 0.0 || stepZ < 0.0) {
             lookAt(firstPos);
+            currentEntityLookingAtPosition = firstPos;
             return;
         }
 
@@ -80,6 +84,7 @@ public class PlayerUtils {
                     Vec3d vec3d = new Vec3d(px + initX, py, pz + initZ);
                     if (isPlayerCanSee(playerEyePos, vec3d, entity)) {
                         lookAt(vec3d);
+                        currentEntityLookingAtPosition = vec3d;
                         return;
                     }
                 }
@@ -88,9 +93,10 @@ public class PlayerUtils {
 
         // Make sure to look at entity even the player can't see it.
         lookAt(firstPos);
+        currentEntityLookingAtPosition = firstPos;
     }
 
-    private static boolean isPlayerCanSee(Vec3d playerEyePos, Vec3d somewhereOnEntity, Entity entity) {
+    public static boolean isPlayerCanSee(Vec3d playerEyePos, Vec3d somewhereOnEntity, Entity entity) {
         BlockHitResult hitResult = entity.getWorld().raycast(
                 new RaycastContext(somewhereOnEntity, playerEyePos,
                         RaycastContext.ShapeType.COLLIDER,

--- a/docs/config.md
+++ b/docs/config.md
@@ -153,7 +153,9 @@ See also: [Feature Description](/docs/features.md#points-of-interest),
 | Play Sound Instead Of Speak             | false         | Play a base drum sound cue on unlock instead of speak `unlock`                               |
 | Auto Lock on to Eye of Ender when Used  | true          | Automatically lock on to the [Eye of Ender](https://minecraft.wiki/w/Eye_of_Ender) when used |
 | Delay (in milliseconds)                 | 100           | Cooldown between two feature executions                                                      |
-| Enable bow aim assist | true | Enable automatic temporary locking onto a nearest monster when using a bow                                              |
+| Bow aim assist | true | Enable automatic temporary locking onto the nearest monster when using a bow                                              |
+| Aim assist sound | true | Enables audio cues for bow aim assist                                                                                   |
+| Aim assist sound volume | 0.5 | Controls the volume of the aim assist audio cues                                                                  |
 
 ### Entities/Blocks Marking
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -153,6 +153,7 @@ See also: [Feature Description](/docs/features.md#points-of-interest),
 | Play Sound Instead Of Speak             | false         | Play a base drum sound cue on unlock instead of speak `unlock`                               |
 | Auto Lock on to Eye of Ender when Used  | true          | Automatically lock on to the [Eye of Ender](https://minecraft.wiki/w/Eye_of_Ender) when used |
 | Delay (in milliseconds)                 | 100           | Cooldown between two feature executions                                                      |
+| Enable bow aim assist | true | Enable automatic temporary locking onto a nearest monster when using a bow                                              |
 
 ### Entities/Blocks Marking
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -145,6 +145,8 @@ See also: [Configuration](/docs/config.md#point-of-interest), [Keybindings](/doc
 You can lock onto the closest target with a key, then your camera will follow the target as it moves, so you can approach it more easily.
 For example, when you want to mine an ore, capture an animal or fight a monster.
 
+The mod will also automatically temporarily lock onto a nearest monster when using a bow if `Enable bow aim assist` is enabled in config.
+
 Note that:
 
 * The mod will continue locking on the position where the eye of ender disappears (if you enabled `Auto Lock on to Eye of Ender when Used` in the config).

--- a/docs/features.md
+++ b/docs/features.md
@@ -145,13 +145,16 @@ See also: [Configuration](/docs/config.md#point-of-interest), [Keybindings](/doc
 You can lock onto the closest target with a key, then your camera will follow the target as it moves, so you can approach it more easily.
 For example, when you want to mine an ore, capture an animal or fight a monster.
 
-The mod will also automatically temporarily lock onto a nearest monster when using a bow if `Enable bow aim assist` is enabled in config.
-
 Note that:
 
 * The mod will continue locking on the position where the eye of ender disappears (if you enabled `Auto Lock on to Eye of Ender when Used` in the config).
 * The mod will automatically stop locking on ladders when you start climbing them, so you can directly climb the ladder without manually pressing the unlock key.
 * The mod will automatically stop locking on blocks if they are destroyed or changed (for example, a [door](https://minecraft.wiki/w/Door) is opened or closed, or a [piston](https://minecraft.wiki/w/Piston) is activated).
+
+#### Bow aim assist
+
+When you start drawing the bow, you will automatically lock onto the nearest hostile mob. A sound will play indicating if you can hit your target and how far the bow has been drawn.
+If the sound playing is a piano, you can shoot the target, and if it's a bass, you can't shoot the target. The sound will increase in pitch 3 times as you draw the bow, stopping when the bow is fully drawn.
 
 See also: [Configuration](/docs/config.md#entitiesblocks-locking), [Keybindings](/docs/keybindings.md#point-of-interest)
 


### PR DESCRIPTION
Closes #212 

Edit: https://github.com/khanshoaib3/minecraft-access-i18n/pull/39 should be merged before this because it contains fields required by this feature

# Changelog
## New Features
- Add basic aim assist for bows (temporarily lock onto the nearest hostile mob when drawing a bow, play sounds indicating how much the bow has been drawn and if the target can be shot)