### PR TITLE
Add mouse simulation support on MacOS

### DIFF
--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/system/MouseUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/system/MouseUtils.java
@@ -68,6 +68,7 @@ public class MouseUtils {
     public static void move(int x, int y) {
         doNativeMouseAction("mouse moving", true,
                 "xdotool mousemove %d %d".formatted(x, y),
+                "cliclick m:%d,%d".formatted(x, y),
                 (i) -> {
                     if (!i.SetCursorPos(x, y)) log.error("\nError encountered on moving mouse.");
                 }
@@ -102,6 +103,7 @@ public class MouseUtils {
     public static void leftClick() {
         doNativeMouseAction("left click", true,
                 "xdotool click 1",
+                "cliclick c:.",
                 (i) -> {
                     i.mouse_event(MouseEventFlags.LEFTDOWN.getValue(), 0, 0, 0, 0);
                     i.mouse_event(MouseEventFlags.LEFTUP.getValue(), 0, 0, 0, 0);
@@ -115,6 +117,7 @@ public class MouseUtils {
     public static void leftDown() {
         doNativeMouseAction("left down", true,
                 "xdotool mousedown 1",
+                "cliclick dd:.",
                 (i) -> i.mouse_event(MouseEventFlags.LEFTDOWN.getValue(), 0, 0, 0, 0)
         );
     }
@@ -125,6 +128,7 @@ public class MouseUtils {
     public static void leftUp() {
         doNativeMouseAction("left up", true,
                 "xdotool mouseup 1",
+                "cliclick du:.",
                 (i) -> i.mouse_event(MouseEventFlags.LEFTUP.getValue(), 0, 0, 0, 0)
         );
     }
@@ -136,6 +140,7 @@ public class MouseUtils {
     public static void middleClick() {
         doNativeMouseAction("middle click", true,
                 "xdotool click 2",
+                "cliclick cc:.",
                 (i) -> {
                     i.mouse_event(MouseEventFlags.MIDDLEDOWN.getValue(), 0, 0, 0, 0);
                     i.mouse_event(MouseEventFlags.MIDDLEUP.getValue(), 0, 0, 0, 0);
@@ -149,6 +154,7 @@ public class MouseUtils {
     public static void middleDown() {
         doNativeMouseAction("middle down", true,
                 "xdotool mousedown 2",
+                "cliclick cdd:.",
                 (i) -> i.mouse_event(MouseEventFlags.MIDDLEDOWN.getValue(), 0, 0, 0, 0)
         );
     }
@@ -159,6 +165,7 @@ public class MouseUtils {
     public static void middleUp() {
         doNativeMouseAction("middle up", true,
                 "xdotool mouseup 2",
+                "cliclick cdu:.",
                 (i) -> i.mouse_event(MouseEventFlags.MIDDLEUP.getValue(), 0, 0, 0, 0)
         );
     }
@@ -169,6 +176,7 @@ public class MouseUtils {
     public static void rightClick() {
         doNativeMouseAction("right click", true,
                 "xdotool click 3",
+                "cliclick rc:.",
                 (i) -> {
                     i.mouse_event(MouseEventFlags.RIGHTDOWN.getValue(), 0, 0, 0, 0);
                     i.mouse_event(MouseEventFlags.RIGHTUP.getValue(), 0, 0, 0, 0);
@@ -182,6 +190,7 @@ public class MouseUtils {
     public static void rightDown() {
         doNativeMouseAction("right down", true,
                 "xdotool mousedown 3",
+                "cliclick rdd:.",
                 (i) -> i.mouse_event(MouseEventFlags.RIGHTDOWN.getValue(), 0, 0, 0, 0)
         );
     }
@@ -192,6 +201,7 @@ public class MouseUtils {
     public static void rightUp() {
         doNativeMouseAction("right up", true,
                 "xdotool mouseup 3",
+                "cliclick rdu:.",
                 (i) -> i.mouse_event(MouseEventFlags.RIGHTUP.getValue(), 0, 0, 0, 0)
         );
     }
@@ -202,6 +212,7 @@ public class MouseUtils {
     public static void scrollUp() {
         doNativeMouseAction("scroll up", false,
                 "xdotool click 4",
+                "cliclick su:.",
                 (i) -> i.mouse_event(MouseEventFlags.WHEEL.getValue(), 0, 0, 120, 0)
         );
     }
@@ -212,10 +223,11 @@ public class MouseUtils {
     public static void scrollDown() {
         doNativeMouseAction("scroll down", false,
                 "xdotool click 5",
+                "cliclick sd:.",
                 (i) -> i.mouse_event(MouseEventFlags.WHEEL.getValue(), 0, 0, -120, 0));
     }
 
-    private static void doNativeMouseAction(String name, boolean logCoordinates, String linuxXdotCommand, Consumer<user32dllInterface> windowsAction) {
+    private static void doNativeMouseAction(String name, boolean logCoordinates, String linuxXdotCommand, String macCliclickCommand, Consumer<user32dllInterface> windowsAction) {
         MinecraftClient minecraftClient = MinecraftClient.getInstance();
         if (minecraftClient == null)
             return;
@@ -232,6 +244,15 @@ public class MouseUtils {
 
             if (OsUtils.isLinux()) {
                 Runtime.getRuntime().exec(linuxXdotCommand);
+            } else if (OsUtils.isMacOS()) {
+                // When Minecraft is launched on MacOS, it does not inherit
+               // the full PATH variable set in /etc/profile
+                // and other shell initialization scripts.
+                // Running /bin/sh with the -l option sources the default
+                // initialization scripts before running the command, which sets
+                // PATH correctly.
+                String[] macCliclickCommandArray = {"/bin/sh", "-l", "-c", macCliclickCommand};
+                Runtime.getRuntime().exec(macCliclickCommandArray);
             } else if (OsUtils.isWindows()) {
                 if (mainInterface == null) initializeUser32dll();
                 windowsAction.accept(mainInterface);

--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/system/OsUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/system/OsUtils.java
@@ -41,6 +41,14 @@ public class OsUtils {
     }
 
     /**
+     * Checks whether the os is macos or not
+     * @return Returns true if os is macos
+     */
+    public static boolean isMacOS() {
+        return getOsName().startsWith("Mac");
+    }
+
+    /**
      * Checks whether the architecture of JRE is 64 bit or not
      * @return Returns true if the architecture is 64 bit
      */

--- a/docs/setup/MacOS.md
+++ b/docs/setup/MacOS.md
@@ -1,0 +1,36 @@
+# Set up on MacOS
+
+This mod is now able to run on MacOS, although with a few caveats:
+
+* The speech will often speak over itself, and there is no way to stop speech
+* The setup process involves compiling and installing a command-line utility that the mod will use to move and click the mouse
+* MacOS support has not been well-tested yet, so you might experience issues
+
+## Compiling Cliclick
+
+[Cliclick](https://github.com/BlueM/cliclick) is a utility that can generate mouse events, similar to xdotool on Linux. You must compile and install it to use this mod on MacOS.
+
+Currently, the main cliclick repository is missing a few features needed for this mod, so you must use [emassey0135's minecraft-additions branch](https://github.com/emassey0135/cliclick/tree/minecraft-additions).  To compile and install it, do the following:
+
+1. Open Terminal
+2. If you have not installed the Xcode Command Line Tools, run `sudo xcode-select --install` and follow the instructions
+3. Run `git clone https://github.com/emassey0135/cliclick -b minecraft-additions` to clone the repository
+4. Change directory into it with `cd cliclick`
+5. Run `make` to compile the project. You can also run `make -Jn`, where n is how many CPU cores you have, to run compilation steps concurrently.
+6. Run `sudo make install` to install the executable into /usr/local/bin
+
+## Enabling Accessibility Permission
+
+MacOS does not allow applications to send input events unless they have the Accessibility permission, so you must grant it before mouse simulation will work.
+
+1. Install the mod and start Minecraft
+2. Start a game
+3. Press a key that triggers a mouse event. Pressing left bracket should work if you have not changed the default keymap.
+4. Open System Settings, and navigate to Privacy and Security > Accessibility
+5. Turn on Minecraft in the applications list
+6. Enter your password when prompted
+7. Close and re-open Minecraft, and mouse simulation should work
+
+## Changing Speech Rate
+
+Since Minecraft uses the Apple text-to-speech API and doesn't speak through VoiceOver, the default speech rate can be very slow. To increase the speech rate the mod uses, open System Settings, and go to Accessibility > Spoken Content. From there, you can change the speech rate and any other settings you would like.


### PR DESCRIPTION
[//]: # (The changelog will be added into CHANGELOG.md file automatically by fast-forward workflow.)

[//]: # (Please delete unrelevant changelog sections.)

## Changelog

### New Features
* Add mouse simulation support on MacOS

[//]: # (The `Development Chores` section won't be included as release notes, it's recorded for developers only.)

### Development Chores

[//]: # (## Keep Writting If You Have Anything Else To Say)

This uses [Cliclick](https://github.com/BlueM/cliclick) to send mouse events. Currently, it does not support all the features needed by the mod, but I have submitted a few pull requests to add them. In the mean time, my [minecraft-additions branch](https://github.com/emassey0135/cliclick/tree/minecraft-additions) can be used.