### PR TITLE
fixed health and hunger string

### DIFF
--- a/common/src/main/resources/assets/minecraft_access/lang/en_us.json
+++ b/common/src/main/resources/assets/minecraft_access/lang/en_us.json
@@ -177,7 +177,7 @@
   "minecraft_access.gui.screen.value_entry_menu": "Value Entry Menu",
   "minecraft_access.gui.speech_settings_config_menu.button.speech_rate": "Speech Rate (percent)",
   "minecraft_access.gui.value_entry_menu.info_text": "Press enter key to accept and escape key to cancel.\tValue: %s",
-  "minecraft_access.health_and_hunger.format": "Health is %s. Hunger is %s",
+  "minecraft_access.healthHunger.format": "Health is %s. Hunger is %s",
   "minecraft_access.inventory_controls.Unknown": "Unknown",
   "minecraft_access.inventory_controls.direction_down": "Down",
   "minecraft_access.inventory_controls.direction_left": "Left",


### PR DESCRIPTION
changed minecraft_access.health_and_Hunger.format to minecraft_access.healthHunger.format

[//]: # (The changelog will be added into CHANGELOG.md file automatically by fast-forward workflow.)

[//]: # (Please delete unrelevant changelog sections.)

## Changelog

### New Features

### Feature Updates

### Bug Fixes
changed minecraft_access.health_and_Hunger.format to minecraft_access.healthHunger.format. this fixes the health and hunger key which wasn't working
### Translation Changes

### Others

[//]: # (The `Development Chores` section won't be included as release notes, it's recorded for developers only.)

### Development Chores

[//]: # (## Keep Writting If You Have Anything Else To Say)