### PR TITLE
Fix entity equipment narration triggering even if entity doesn't have equipment

### DIFF
--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/NarrationUtils.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/utils/NarrationUtils.java
@@ -105,7 +105,7 @@ public class NarrationUtils {
             }
         }
 
-        if (!Strings.isBlank(equipments.toString())) {
+        if (!equipments.isEmpty()) {
             String wordConnection = I18n.translate("minecraft_access.other.words_connection");
             var values = Map.of("entity", text, "equipments", String.join(wordConnection, equipments));
             //noinspection SuperfluousFormat


### PR DESCRIPTION
Fixes #368 

# Changelog
## Bug Fixes
- Fix equipment narration triggering even if entity doesn't have equipment