### PR TITLE
Autofix: Locking feature doesn't unlock when the block is destroyed

### DIFF
--- a/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/LockingHandler.java
+++ b/common/src/main/java/com/github/khanshoaib3/minecraft_access/features/point_of_interest/LockingHandler.java
@@ -104,7 +104,14 @@ public class LockingHandler {
         }
 
         if (lockedOnBlock != null) {
-            BlockState blockState = minecraftClient.world.getBlockState(WorldUtils.blockPosOf(lockedOnBlock.getAccuratePosition()));
+            BlockPos blockPos = WorldUtils.blockPosOf(lockedOnBlock.getAccuratePosition());
+            BlockState blockState = minecraftClient.world.getBlockState(blockPos);
+
+            if (blockState.isAir()) {
+                unlock(true);
+                return;
+            }
+            // Check if the block state has changed
 
             if (unlockFromLadderIfClimbingOnIt(blockState)) return;
 


### PR DESCRIPTION
Modified the LockingHandler class to check if the locked block still exists and unlock if it doesn't. This fixes the issue where the player remains locked onto a destroyed block's position. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    