### PR TITLE
revert: gradle version 8.12 to 8.11.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,7 +86,8 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
+' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum


### PR DESCRIPTION
Because gradle 8.12 causes "common.mixins.json" not exists in build result.
See https://discord.com/channels/792699517631594506/1322766571135041586
The content of the link pasted below:

The build result with gradle 8.12:
https://github.com/minecraft-access/minecraft-access/actions/runs/12511552881
causes:
```
[12:57:51] [main/ERROR]: Uncaught exception in thread "main"
java.lang.RuntimeException: Error parsing or using Mixin config minecraft_access-common.mixins.json for mod minecraft_access
    at net.fabricmc.loader.impl.launch.FabricMixinBootstrap.init(FabricMixinBootstrap.java:96) ~[fabric-loader-0.16.9.jar:?]
    at net.fabricmc.loader.impl.launch.knot.Knot.init(Knot.java:151) ~[fabric-loader-0.16.9.jar:?]
    at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:68) ~[fabric-loader-0.16.9.jar:?]
    at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) ~[fabric-loader-0.16.9.jar:?]
Caused by: org.spongepowered.asm.launch.MixinInitialisationError: Error initialising mixin config minecraft_access-common.mixins.json
    at org.spongepowered.asm.mixin.transformer.Config.create(Config.java:168) ~[sponge-mixin-0.15.4+mixin.0.8.7.jar:0.15.4+mixin.0.8.7]
    at org.spongepowered.asm.mixin.Mixins.createConfiguration(Mixins.java:121) ~[sponge-mixin-0.15.4+mixin.0.8.7.jar:0.15.4+mixin.0.8.7]
    at org.spongepowered.asm.mixin.Mixins.addConfiguration(Mixins.java:108) ~[sponge-mixin-0.15.4+mixin.0.8.7.jar:0.15.4+mixin.0.8.7]
    at org.spongepowered.asm.mixin.Mixins.addConfiguration(Mixins.java:98) ~[sponge-mixin-0.15.4+mixin.0.8.7.jar:0.15.4+mixin.0.8.7]
    at net.fabricmc.loader.impl.launch.FabricMixinBootstrap.init(FabricMixinBootstrap.java:94) ~[fabric-loader-0.16.9.jar:?]
    ... 3 more
Caused by: java.lang.IllegalArgumentException: The specified resource 'minecraft_access-common.mixins.json' was invalid or could not be read
    at org.spongepowered.asm.mixin.transformer.MixinConfig.create(MixinConfig.java:1395) ~[sponge-mixin-0.15.4+mixin.0.8.7.jar:0.15.4+mixin.0.8.7]
    at org.spongepowered.asm.mixin.transformer.Config.create(Config.java:163) ~[sponge-mixin-0.15.4+mixin.0.8.7.jar:0.15.4+mixin.0.8.7]
    at org.spongepowered.asm.mixin.Mixins.createConfiguration(Mixins.java:121) ~[sponge-mixin-0.15.4+mixin.0.8.7.jar:0.15.4+mixin.0.8.7]
    at org.spongepowered.asm.mixin.Mixins.addConfiguration(Mixins.java:108) ~[sponge-mixin-0.15.4+mixin.0.8.7.jar:0.15.4+mixin.0.8.7]
    at org.spongepowered.asm.mixin.Mixins.addConfiguration(Mixins.java:98) ~[sponge-mixin-0.15.4+mixin.0.8.7.jar:0.15.4+mixin.0.8.7]
    at net.fabricmc.loader.impl.launch.FabricMixinBootstrap.init(FabricMixinBootstrap.java:94) ~[fabric-loader-0.16.9.jar:?]
    ... 3 more
```
It turns out that the `minecraft_access-common.mixins.json` isn't exist in the `minecraft-access-1.9.0-SNAPSHOT.102+fabric.jar` jar (and neoforge jar).

While the build result with gradle 8.11.1 works:
https://github.com/minecraft-access/minecraft-access/actions/runs/12489457004

It worth note that you can start the game normally within IDE, but both local build result and CI build result cause the game crush in production.
I'm not familiar with gradle, I guess the 8.12 version of gradle breaks some logic inside arch loom...