### PR TITLE
update deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     // From developers of architectury: "shouldn't hardcode the loom version, just put *-SNAPSHOT"
     // ref: https://maven.architectury.dev/dev/architectury/architectury-loom/
     id "dev.architectury.loom" version "1.9-SNAPSHOT" apply false
-    id 'com.palantir.git-version' version '3.0.0'
+    id 'com.palantir.git-version' version '3.1.0'
 }
 
 def git = versionDetails()

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,8 +9,8 @@ maven_group=org.mcaccess.minecraftaccess
 # To find the latest version numbers for things in this file
 architectury_api_version=15.0.1
 fabric_loader_version=0.16.10
-fabric_api_version=0.115.0+1.21.4
-jade_fabric_version=17.2.0
+fabric_api_version=0.116.1+1.21.4
+jade_fabric_version=17.2.2
 
-neoforge_version=21.4.74-beta
-jade_neoforge_version=17.1.2
+neoforge_version=21.4.89-beta
+jade_neoforge_version=17.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ archives_base_name=minecraft-access
 enabled_platforms=fabric,neoforge
 minecraft_version=1.21.4
 # Refer to https://parchmentmc.org/docs/getting-started for version table
-parchment_version=2025.01.19
+parchment_version=2025.02.16
 maven_group=org.mcaccess.minecraftaccess
 # https://linkie.shedaniel.dev/dependencies
 # To find the latest version numbers for things in this file

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ maven_group=org.mcaccess.minecraftaccess
 # To find the latest version numbers for things in this file
 architectury_api_version=15.0.1
 fabric_loader_version=0.16.10
-fabric_api_version=0.116.1+1.21.4
+fabric_api_version=0.117.0+1.21.4
 jade_fabric_version=17.2.2
 
 neoforge_version=21.4.89-beta

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum


### PR DESCRIPTION
This PR updates dependencies. It also updates gradle to 8.12.1, as Architectury [fixed the issue](https://github.com/architectury/architectury-plugin/commit/75f2a021e3692aa3a871625c2ef66ae77ca43040) blocking the upgrade. Being on the newest gradle version insures project security, optimized compile times, and more.