### PR TITLE
refactor: move item speaking injection point for neoforge out again

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
@@ -25,7 +25,7 @@ import java.util.List;
  * Narrates titles
  */
 @Mixin(Gui.class)
-public class GuiMixin {
+abstract class GuiMixin {
     @Shadow
     private int toolHighlightTimer;
 
@@ -49,13 +49,11 @@ public class GuiMixin {
      * so we use previousContent to check if the content has changed and need to be narrated.
      */
     @WrapOperation(
-            method = {"Lnet/minecraft/client/gui/Gui;renderSelectedItemName(Lnet/minecraft/client/gui/GuiGraphics;I)V", "Lnet/minecraft/client/gui/Gui;renderSelectedItemName(Lnet/minecraft/client/gui/GuiGraphics;)V"},
+            method = "renderSelectedItemName(Lnet/minecraft/client/gui/GuiGraphics;)V",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiling/ProfilerFiller;pop()V")
     )
-    private void speakItemName(ProfilerFiller profiler, Operation<Void> original) {
+    protected void speakItemName(ProfilerFiller profiler, Operation<Void> original) {
         this.minecraft_access$feature.speakHeldItem(this.lastToolHighlight, this.toolHighlightTimer);
-
-
         original.call(profiler);
     }
 

--- a/neoforge/src/main/java/org/mcaccess/minecraftaccess/neoforge/GuiMixin.java
+++ b/neoforge/src/main/java/org/mcaccess/minecraftaccess/neoforge/GuiMixin.java
@@ -1,0 +1,40 @@
+package org.mcaccess.minecraftaccess.neoforge;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.minecraft.world.item.ItemStack;
+import org.mcaccess.minecraftaccess.features.SpeakHeldItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(Gui.class)
+abstract class GuiMixin {
+    @Shadow
+    private int toolHighlightTimer;
+
+    @Shadow
+    private ItemStack lastToolHighlight;
+
+    @Unique
+    private final SpeakHeldItem minecraft_access$feature = new SpeakHeldItem();
+
+    /**
+     * Same as {@link org.mcaccess.minecraftaccess.mixin.GuiMixin#speakItemName(ProfilerFiller, Operation)}
+     * Neoforge patched the original {@link Gui#renderSelectedItemName(GuiGraphics)} method to make it as two methods,
+     * and invoke the new method instead.
+     * <a href="https://github.com/neoforged/NeoForge/blob/821e47fe8e30663d4511530787a16f9d48f38b3f/patches/net/minecraft/client/gui/Gui.java.patch#L225">patch link</a>
+     */
+    @WrapOperation(
+            method = "renderSelectedItemName(Lnet/minecraft/client/gui/GuiGraphics;I)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiling/ProfilerFiller;pop()V")
+    )
+    protected void speakItemName(ProfilerFiller profiler, Operation<Void> original) {
+        this.minecraft_access$feature.speakHeldItem(this.lastToolHighlight, this.toolHighlightTimer);
+        original.call(profiler);
+    }
+}

--- a/neoforge/src/main/resources/neoforge.mixin.json
+++ b/neoforge/src/main/resources/neoforge.mixin.json
@@ -1,0 +1,12 @@
+{
+  "required": false,
+  "minVersion": "0.8",
+  "package": "org.mcaccess.minecraftaccess.neoforge",
+  "compatibilityLevel": "JAVA_21",
+  "client": [
+    "GuiMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
## Why picky on that warning?

In development we debug run the game a lot, at every running this warning will set the focus of IDE debug panel to itself and I need to manually focus on debug output, it's annoying.

## Any other way to suppress the warning?

I tried things like `@SuppressWarnings("UnresolvedMixinReference")` but none of them works. All my want is suppress this exact warning, so easier ways are welcomed.

## Any other way to reuse the mixin code?

Sadly, nope. The target class, `Gui` doesn't have parents so I can't use [Mixin Inheritance](https://wiki.fabricmc.net/tutorial:mixinheritance).