### PR TITLE
Fixed Mixin warning

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
@@ -39,6 +39,7 @@ public class MainClass {
     public static PlayerWarnings playerWarnings = null;
     public static AccessMenu accessMenu = null;
     public static FluidDetector fluidDetector = null;
+    public static SpeakHeldItem speakHeldItem = null;
 
     public static boolean isNeoForge = Platform.isNeoForge();
     public static boolean interrupt = true;
@@ -67,6 +68,7 @@ public class MainClass {
         MainClass.playerWarnings = new PlayerWarnings();
         MainClass.accessMenu = new AccessMenu();
         MainClass.fluidDetector = new FluidDetector();
+        speakHeldItem = new SpeakHeldItem();
 
         for (KeyMapping km : KeyBindingsHandler.getInstance().getKeys()) {
             KeyMappingRegistry.register(km);
@@ -130,6 +132,8 @@ public class MainClass {
 
         if (accessMenu != null && AccessMenuConfigMap.getInstance().isEnabled())
             accessMenu.update();
+
+        speakHeldItem.speakHeldItem();
 
         // POI Marking will handle POI Scan and POI Locking features inside it
         POIMarking.getInstance().update();

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/SpeakHeldItem.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/SpeakHeldItem.java
@@ -1,10 +1,12 @@
 package org.mcaccess.minecraftaccess.features;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.world.item.ItemStack;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.config.config_maps.OtherConfigsMap;
 import org.mcaccess.minecraftaccess.features.inventory_controls.InventoryControls;
+import org.mcaccess.minecraftaccess.mixin.GuiAccessor;
 
 import java.util.function.Function;
 
@@ -18,7 +20,9 @@ public class SpeakHeldItem {
     public static final Function<String, String> HOTBAR_I18N = toSpeak -> I18n.get("minecraft_access.other.selected", toSpeak);
     public static final Function<String, String> EMPTY_SLOT_I18N = toSpeak -> I18n.get("minecraft_access.inventory_controls.empty_slot", toSpeak);
 
-    public void speakHeldItem(ItemStack currentStack, int heldItemTooltipFade) {
+    public void speakHeldItem() {
+        ItemStack currentStack = ((GuiAccessor) Minecraft.getInstance().gui).getLastToolHighlight();
+        int heldItemTooltipFade = ((GuiAccessor) Minecraft.getInstance().gui).getToolHighlightTimer();
         boolean currentStackIsEmpty = currentStack.isEmpty();
         if (heldItemTooltipFade == 0 && currentStackIsEmpty) {
             // Speak "empty slot" when the selected slot is empty

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiAccessor.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiAccessor.java
@@ -1,0 +1,15 @@
+package org.mcaccess.minecraftaccess.mixin;
+
+import net.minecraft.client.gui.Gui;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Gui.class)
+public interface GuiAccessor {
+    @Accessor
+    int getToolHighlightTimer();
+
+    @Accessor
+    ItemStack getLastToolHighlight();
+}

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
@@ -1,14 +1,9 @@
 package org.mcaccess.minecraftaccess.mixin;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.profiling.ProfilerFiller;
-import net.minecraft.world.item.ItemStack;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.config.config_maps.OtherConfigsMap;
-import org.mcaccess.minecraftaccess.features.SpeakHeldItem;
 import org.mcaccess.minecraftaccess.utils.StringUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -27,37 +22,13 @@ import java.util.List;
 @Mixin(Gui.class)
 public class GuiMixin {
     @Shadow
-    private int toolHighlightTimer;
-
-    @Shadow
-    private ItemStack lastToolHighlight;
-
-    @Shadow
     private Component title;
 
     @Shadow
     private Component subtitle;
 
     @Unique
-    private final SpeakHeldItem minecraft_access$feature = new SpeakHeldItem();
-
-    @Unique
     private String minecraft_access$previousActionBarContent = "";
-
-    /**
-     * This method is continually invoked by the Gui.render(),
-     * so we use previousContent to check if the content has changed and need to be narrated.
-     */
-    @WrapOperation(
-            method = {"Lnet/minecraft/client/gui/Gui;renderSelectedItemName(Lnet/minecraft/client/gui/GuiGraphics;I)V", "Lnet/minecraft/client/gui/Gui;renderSelectedItemName(Lnet/minecraft/client/gui/GuiGraphics;)V"},
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiling/ProfilerFiller;pop()V")
-    )
-    private void speakItemName(ProfilerFiller profiler, Operation<Void> original) {
-        this.minecraft_access$feature.speakHeldItem(this.lastToolHighlight, this.toolHighlightTimer);
-
-
-        original.call(profiler);
-    }
 
     @Inject(at = @At("HEAD"), method = "setOverlayMessage(Lnet/minecraft/network/chat/Component;Z)V")
     public void speakActionbar(Component message, boolean tinted, CallbackInfo ci) {

--- a/common/src/main/resources/minecraft_access.mixins.json
+++ b/common/src/main/resources/minecraft_access.mixins.json
@@ -24,6 +24,7 @@
     "EntityAccessor",
     "EyeOfEnderMixin",
     "GameNarratorMixin",
+    "GuiAccessor",
     "GuiGraphicsMixin",
     "GuiMixin",
     "I18NAccessor",


### PR DESCRIPTION
Fixes the Mixin warning by moving the offending code to the tick event handler.

There was nothing special about the offending injection point, all that matters is that we call the `SpeakHeldItem#speakHeldItem()` method every tick.