### PR TITLE
Added scroll keys to chat screen

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
@@ -28,14 +28,14 @@ public class ChatScreenMixin {
     private static final Component USAGE_TEXT = Component.translatable("chat_screen.usage");
 
     @Unique
-    private static int minecraft_access$chatMessagePage;
+    private static int minecraft_access$currentChatMessagePage;
 
     @Shadow
     protected EditBox input;
 
     @Inject(at = @At("HEAD"), method = "init")
     private void init(CallbackInfo ci) {
-        minecraft_access$chatMessagePage = 0;
+        minecraft_access$currentChatMessagePage = 0;
     }
 
     /**
@@ -80,40 +80,41 @@ public class ChatScreenMixin {
     private static boolean minecraft_access$repeatPreviousChatMessage(int keyCode) {
         long window = Minecraft.getInstance().getWindow().getWindow();
         int numMessages = ((ChatComponentAccessor) Minecraft.getInstance().gui.getChat()).getAllMessages().size();
-        int oldChatMessagePage = minecraft_access$chatMessagePage;
+        int newChatMessagePage = minecraft_access$currentChatMessagePage;
         if (Screen.hasAltDown()) {
             if (InputConstants.isKeyDown(window, InputConstants.KEY_GRAVE) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_MULTIPLY)) {
                 if (Screen.hasControlDown()) {
-                    minecraft_access$chatMessagePage = numMessages / 10;
+                    newChatMessagePage = numMessages / 10;
                 } else {
-                    minecraft_access$chatMessagePage = 0;
+                    newChatMessagePage = 0;
                 }
             } else if (InputConstants.isKeyDown(window, InputConstants.KEY_EQUALS) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_ADD)) {
-                minecraft_access$chatMessagePage -= 1;
+                newChatMessagePage -= 1;
                 if (Screen.hasControlDown()) {
-                    minecraft_access$chatMessagePage -= 4;
+                    newChatMessagePage -= 4;
                 }
             } else if (InputConstants.isKeyDown(window, InputConstants.KEY_MINUS) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_SUBTRACT)) {
-                minecraft_access$chatMessagePage += 1;
+                newChatMessagePage += 1;
                 if (Screen.hasControlDown()) {
-                    minecraft_access$chatMessagePage += 4;
+                    newChatMessagePage += 4;
                 }
             }
 
-            minecraft_access$chatMessagePage = Math.clamp(minecraft_access$chatMessagePage, 0, numMessages / 10);
+            newChatMessagePage = Math.clamp(newChatMessagePage, 0, numMessages / 10);
 
-            if (oldChatMessagePage != minecraft_access$chatMessagePage) {
-                MainClass.speakWithNarrator(I18n.get("minecraft_access.gui.chat_screen.showing_message_range", (minecraft_access$chatMessagePage * 10) + 1, (minecraft_access$chatMessagePage + 1) * 10), true);
+            if (newChatMessagePage != minecraft_access$currentChatMessagePage) {
+                minecraft_access$currentChatMessagePage = newChatMessagePage;
+                MainClass.speakWithNarrator(I18n.get("minecraft_access.gui.chat_screen.showing_message_range", (newChatMessagePage * 10) + 1, (newChatMessagePage + 1) * 10), true);
             }
 
             for (int i = 1; i <= 9; i++) {
                 if (keyCode == GLFW.GLFW_KEY_0 + i || keyCode == GLFW.GLFW_KEY_KP_0 + i) {
-                    minecraft_access$speakPreviousChatAtIndex(i + minecraft_access$chatMessagePage * 10 - 1);
+                    minecraft_access$speakPreviousChatAtIndex(i + minecraft_access$currentChatMessagePage * 10 - 1);
                     return true;
                 }
             }
             if (InputConstants.isKeyDown(window, GLFW.GLFW_KEY_0) || InputConstants.isKeyDown(window, InputConstants.KEY_NUMPAD0)) {
-                minecraft_access$speakPreviousChatAtIndex(10 + minecraft_access$chatMessagePage * 10 - 1);
+                minecraft_access$speakPreviousChatAtIndex(10 + minecraft_access$currentChatMessagePage * 10 - 1);
             }
         }
         return false;

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
@@ -28,14 +28,14 @@ public class ChatScreenMixin {
     private static final Component USAGE_TEXT = Component.translatable("chat_screen.usage");
 
     @Unique
-    private static int minecraft_access$chatMessageOffset;
+    private static int minecraft_access$chatMessagePage;
 
     @Shadow
     protected EditBox input;
 
     @Inject(at = @At("HEAD"), method = "init")
     private void init(CallbackInfo ci) {
-        minecraft_access$chatMessageOffset = 0;
+        minecraft_access$chatMessagePage = 0;
     }
 
     /**
@@ -80,45 +80,40 @@ public class ChatScreenMixin {
     private static boolean minecraft_access$repeatPreviousChatMessage(int keyCode) {
         long window = Minecraft.getInstance().getWindow().getWindow();
         int numMessages = ((ChatComponentAccessor) Minecraft.getInstance().gui.getChat()).getAllMessages().size();
-        int oldOffset = minecraft_access$chatMessageOffset;
+        int oldChatMessagePage = minecraft_access$chatMessagePage;
         if (Screen.hasAltDown()) {
             if (InputConstants.isKeyDown(window, InputConstants.KEY_GRAVE) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_MULTIPLY)) {
                 if (Screen.hasControlDown()) {
-                    minecraft_access$chatMessageOffset = Math.max(0, ((numMessages - 1) / 10) * 10);
+                    minecraft_access$chatMessagePage = numMessages / 10;
                 } else {
-                    minecraft_access$chatMessageOffset = 0;
+                    minecraft_access$chatMessagePage = 0;
                 }
-            } else if ((InputConstants.isKeyDown(window, InputConstants.KEY_EQUALS) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_ADD)) && minecraft_access$chatMessageOffset >= 10) {
-                minecraft_access$chatMessageOffset -= 10;
+            } else if (InputConstants.isKeyDown(window, InputConstants.KEY_EQUALS) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_ADD)) {
+                minecraft_access$chatMessagePage -= 1;
                 if (Screen.hasControlDown()) {
-                    if (minecraft_access$chatMessageOffset - 40 >= 0) {
-                        minecraft_access$chatMessageOffset -= 40;
-                    } else {
-                        minecraft_access$chatMessageOffset = 0;
-                    }
+                    minecraft_access$chatMessagePage -= 4;
                 }
-            } else if ((InputConstants.isKeyDown(window, InputConstants.KEY_MINUS) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_SUBTRACT)) && minecraft_access$chatMessageOffset + 10 < numMessages) {
-                minecraft_access$chatMessageOffset += 10;
+            } else if (InputConstants.isKeyDown(window, InputConstants.KEY_MINUS) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_SUBTRACT)) {
+                minecraft_access$chatMessagePage += 1;
                 if (Screen.hasControlDown()) {
-                    if (minecraft_access$chatMessageOffset + 40 < numMessages) {
-                        minecraft_access$chatMessageOffset += 40;
-                    } else {
-                        minecraft_access$chatMessageOffset = Math.max(0, ((numMessages - 1) / 10) * 10);
-                    }
+                    minecraft_access$chatMessagePage += 4;
                 }
             }
 
-            if (oldOffset != minecraft_access$chatMessageOffset)
-                MainClass.speakWithNarrator(I18n.get("minecraft_access.gui.chat_screen.showing_message_range", minecraft_access$chatMessageOffset + 1, minecraft_access$chatMessageOffset + 10), true);
+            minecraft_access$chatMessagePage = Math.clamp(minecraft_access$chatMessagePage, 0, numMessages / 10);
+
+            if (oldChatMessagePage != minecraft_access$chatMessagePage) {
+                MainClass.speakWithNarrator(I18n.get("minecraft_access.gui.chat_screen.showing_message_range", (minecraft_access$chatMessagePage * 10) + 1, (minecraft_access$chatMessagePage + 1) * 10), true);
+            }
 
             for (int i = 1; i <= 9; i++) {
                 if (keyCode == GLFW.GLFW_KEY_0 + i || keyCode == GLFW.GLFW_KEY_KP_0 + i) {
-                    minecraft_access$speakPreviousChatAtIndex(i + minecraft_access$chatMessageOffset - 1);
+                    minecraft_access$speakPreviousChatAtIndex(i + minecraft_access$chatMessagePage * 10 - 1);
                     return true;
                 }
             }
             if (InputConstants.isKeyDown(window, GLFW.GLFW_KEY_0) || InputConstants.isKeyDown(window, InputConstants.KEY_NUMPAD0)) {
-                minecraft_access$speakPreviousChatAtIndex(10 + minecraft_access$chatMessageOffset - 1);
+                minecraft_access$speakPreviousChatAtIndex(10 + minecraft_access$chatMessagePage * 10 - 1);
             }
         }
         return false;

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
@@ -1,5 +1,6 @@
 package org.mcaccess.minecraftaccess.mixin;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.GuiMessage;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.EditBox;
@@ -7,6 +8,7 @@ import net.minecraft.client.gui.narration.NarratedElementType;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 import org.mcaccess.minecraftaccess.MainClass;
@@ -20,11 +22,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.List;
 
-
 @Mixin(ChatScreen.class)
 public class ChatScreenMixin {
     @Unique
     private static final Component USAGE_TEXT = Component.translatable("chat_screen.usage");
+
+    @Unique
+    private static int minecraft_access$chatMessageOffset = 0;
 
     @Shadow
     protected EditBox input;
@@ -69,12 +73,47 @@ public class ChatScreenMixin {
      */
     @Unique
     private static boolean minecraft_access$repeatPreviousChatMessage(int keyCode) {
+        long window = Minecraft.getInstance().getWindow().getWindow();
+        int numMessages = ((ChatComponentAccessor) Minecraft.getInstance().gui.getChat()).getAllMessages().size();
+        int oldOffset = minecraft_access$chatMessageOffset;
         if (Screen.hasAltDown()) {
+            if (InputConstants.isKeyDown(window, InputConstants.KEY_GRAVE) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_MULTIPLY)) {
+                if (Screen.hasControlDown()) {
+                    minecraft_access$chatMessageOffset = Math.max(0, ((numMessages - 1) / 10) * 10);
+                } else {
+                    minecraft_access$chatMessageOffset = 0;
+                }
+            } else if ((InputConstants.isKeyDown(window, InputConstants.KEY_EQUALS) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_ADD)) && minecraft_access$chatMessageOffset >= 10) {
+                minecraft_access$chatMessageOffset -= 10;
+                if (Screen.hasControlDown()) {
+                    if (minecraft_access$chatMessageOffset - 40 >= 0) {
+                        minecraft_access$chatMessageOffset -= 40;
+                    } else {
+                        minecraft_access$chatMessageOffset = 0;
+                    }
+                }
+            } else if ((InputConstants.isKeyDown(window, InputConstants.KEY_MINUS) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_SUBTRACT)) && minecraft_access$chatMessageOffset + 10 < numMessages) {
+                minecraft_access$chatMessageOffset += 10;
+                if (Screen.hasControlDown()) {
+                    if (minecraft_access$chatMessageOffset + 40 < numMessages) {
+                        minecraft_access$chatMessageOffset += 40;
+                    } else {
+                        minecraft_access$chatMessageOffset = Math.max(0, ((numMessages - 1) / 10) * 10);
+                    }
+                }
+            }
+
+            if (oldOffset != minecraft_access$chatMessageOffset)
+                MainClass.speakWithNarrator(I18n.get("minecraft_access.gui.chat_screen.showing_message_range", minecraft_access$chatMessageOffset + 1, minecraft_access$chatMessageOffset + 10), true);
+
             for (int i = 1; i <= 9; i++) {
                 if (keyCode == GLFW.GLFW_KEY_0 + i || keyCode == GLFW.GLFW_KEY_KP_0 + i) {
-                    minecraft_access$speakPreviousChatAtIndex(i - 1);
+                    minecraft_access$speakPreviousChatAtIndex(i + minecraft_access$chatMessageOffset - 1);
                     return true;
                 }
+            }
+            if (InputConstants.isKeyDown(window, GLFW.GLFW_KEY_0) || InputConstants.isKeyDown(window, InputConstants.KEY_NUMPAD0)) {
+                minecraft_access$speakPreviousChatAtIndex(10 + minecraft_access$chatMessageOffset - 1);
             }
         }
         return false;

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
@@ -28,10 +28,15 @@ public class ChatScreenMixin {
     private static final Component USAGE_TEXT = Component.translatable("chat_screen.usage");
 
     @Unique
-    private static int minecraft_access$chatMessageOffset = 0;
+    private static int minecraft_access$chatMessageOffset;
 
     @Shadow
     protected EditBox input;
+
+    @Inject(at = @At("HEAD"), method = "init")
+    private void init(CallbackInfo ci) {
+        minecraft_access$chatMessageOffset = 0;
+    }
 
     /**
      * Removes `message to send` from the spoken text when entering a chat message.

--- a/common/src/main/resources/assets/minecraft_access/lang/en_us.json
+++ b/common/src/main/resources/assets/minecraft_access/lang/en_us.json
@@ -59,6 +59,7 @@
   "minecraft_access.gui.access_menu_config_menu.button.fluid_detector_button": "Fluid Detector Configs",
   "minecraft_access.gui.camera_controls_config_menu.button.modified_rotating_angle": "Modified Rotation Angle",
   "minecraft_access.gui.camera_controls_config_menu.button.normal_rotating_angle": "Normal Rotation Angle",
+  "minecraft_access.gui.chat_screen.showing_message_range": "Showing messages %d threw %d",
   "minecraft_access.gui.common.button.button_with_float_value": "%s: %f",
   "minecraft_access.gui.common.button.button_with_int_value": "%s: %d",
   "minecraft_access.gui.common.button.button_with_string_value": "%s: %s",

--- a/common/src/main/resources/assets/minecraft_access/lang/en_us.json
+++ b/common/src/main/resources/assets/minecraft_access/lang/en_us.json
@@ -59,7 +59,7 @@
   "minecraft_access.gui.access_menu_config_menu.button.fluid_detector_button": "Fluid Detector Configs",
   "minecraft_access.gui.camera_controls_config_menu.button.modified_rotating_angle": "Modified Rotation Angle",
   "minecraft_access.gui.camera_controls_config_menu.button.normal_rotating_angle": "Normal Rotation Angle",
-  "minecraft_access.gui.chat_screen.showing_message_range": "Showing messages %d threw %d",
+  "minecraft_access.gui.chat_screen.showing_message_range": "Showing messages %d through %d",
   "minecraft_access.gui.common.button.button_with_float_value": "%s: %f",
   "minecraft_access.gui.common.button.button_with_int_value": "%s: %d",
   "minecraft_access.gui.common.button.button_with_string_value": "%s: %s",

--- a/docs/content/keybindings.md
+++ b/docs/content/keybindings.md
@@ -161,10 +161,15 @@ See also: [Feature Description]({{% relref "/features#book-editing" %}})
 
 ### Speak Chat Messages
 
-| Key Combination                                          | Description                                                                                                                                    |
-|----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| `Alt` + Number Keys (Upper number keys and key pad keys) | Speak previous chat message (again) corresponding to the number, 1 for the most recent message, 2 for the second most recent message and so on |
-
+| Key Combination                                                      | Description                                                                                                                                    |
+|----------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Alt` + Number Keys (Upper number keys and key pad keys) (1 threw 0) | Speak previous chat message (again) corresponding to the number, 1 for the most recent message, 2 for the second most recent message and so on |
+| `alt` + - or `alt` + numpad minus                                    | Go back a page in the chat history to the next set of 10 messages |
+| `alt` + `control` + - or `alt` + `control` + numpad minus            | Move back in the chat history by 5 pages (if there is less than 5 pages left you will be moved to the last available page)
+| `alt` + = or `alt` + numpad plus                                     | Go forward a page towards the most recent message
+| `alt` + `control` + = or `alt` + `control` + numpad plus             | Move back in the chat history by 5 pages (if there is less than 5 pages left you will be moved to the last available page)
+| `alt` + \` or `alt` + numpad multiply                                | Go to the most recent page of messages
+| `alt` + `control` + \` or `alt` + `control` + numpad multiply        | Go to the oldest page of messages available to your client
 This feature only works while the Chat Screen is open.
 These keys aren’t re-mappable.
 The chat message will be spoken when that message shows up, whether the sender is you or not.

--- a/docs/content/keybindings.md
+++ b/docs/content/keybindings.md
@@ -164,12 +164,13 @@ See also: [Feature Description]({{% relref "/features#book-editing" %}})
 | Key Combination                                                      | Description                                                                                                                                    |
 |----------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
 | `Alt` + Number Keys (Upper number keys and key pad keys) (1 threw 0) | Speak previous chat message (again) corresponding to the number, 1 for the most recent message, 2 for the second most recent message and so on |
-| `alt` + - or `alt` + numpad minus                                    | Go back a page in the chat history to the next set of 10 messages |
-| `alt` + `control` + - or `alt` + `control` + numpad minus            | Move back in the chat history by 5 pages (if there is less than 5 pages left you will be moved to the last available page)
-| `alt` + = or `alt` + numpad plus                                     | Go forward a page towards the most recent message
-| `alt` + `control` + = or `alt` + `control` + numpad plus             | Move back in the chat history by 5 pages (if there is less than 5 pages left you will be moved to the last available page)
-| `alt` + \` or `alt` + numpad multiply                                | Go to the most recent page of messages
-| `alt` + `control` + \` or `alt` + `control` + numpad multiply        | Go to the oldest page of messages available to your client
+| `alt` + - or `alt` + numpad minus                                    | Go back a page in the chat history to the next set of 10 messages                                                                              |
+| `alt` + `control` + - or `alt` + `control` + numpad minus            | Move back in the chat history by 5 pages (if there is less than 5 pages left you will be moved to the last available page)                     |
+| `alt` + = or `alt` + numpad plus                                     | Go forward a page towards the most recent message                                                                                              |
+| `alt` + `control` + = or `alt` + `control` + numpad plus             | Move back in the chat history by 5 pages (if there is less than 5 pages left you will be moved to the last available page)                     |
+| `alt` + \` or `alt` + numpad multiply                                | Go to the most recent page of messages                                                                                                         |
+| `alt` + `control` + \` or `alt` + `control` + numpad multiply        | Go to the oldest page of messages available to your client                                                                                     |
+
 This feature only works while the Chat Screen is open.
 These keys aren’t re-mappable.
 The chat message will be spoken when that message shows up, whether the sender is you or not.


### PR DESCRIPTION
# Changelog

## New Features
- You can now scroll through old chat messages. View the [keybinding docs](https://docs.mcaccess.org/keybindings/#speak-chat-messages) for the commands
- You can now use `alt` + `0` or `alt` + `numpad 0` to hear the 10th message on a chat page