### PR TITLE
Narrate whether a checkbox is checked or unchecked

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/CheckboxMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/CheckboxMixin.java
@@ -1,0 +1,29 @@
+package org.mcaccess.minecraftaccess.mixin;
+
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.Checkbox;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.gui.narration.NarratedElementType;
+import net.minecraft.network.chat.Component;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(Checkbox.class)
+public abstract class CheckboxMixin extends AbstractWidget {
+    @Shadow private boolean selected;
+
+    @Overwrite
+    public void updateWidgetNarration(NarrationElementOutput builder) {
+        if (selected) {
+            builder.add(NarratedElementType.TITLE, Component.translatable("minecraft_access.gui.checkbox_checked", this.getMessage()));
+        }
+        else {
+            builder.add(NarratedElementType.TITLE, Component.translatable("minecraft_access.gui.checkbox_unchecked", this.getMessage()));
+        }
+    }
+
+    public CheckboxMixin(int x, int y, int width, int height, Component message) {
+        super(x, y, width, height, message);
+    }
+}

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/CheckboxMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/CheckboxMixin.java
@@ -11,7 +11,8 @@ import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(Checkbox.class)
 public abstract class CheckboxMixin extends AbstractWidget {
-    @Shadow private boolean selected;
+    @Shadow
+    private boolean selected;
 
     @Overwrite
     public void updateWidgetNarration(NarrationElementOutput builder) {

--- a/common/src/main/resources/assets/minecraft_access/lang/en_us.json
+++ b/common/src/main/resources/assets/minecraft_access/lang/en_us.json
@@ -57,6 +57,8 @@
   "minecraft_access.direction.straight": "Straight",
   "minecraft_access.direction.up": "Up",
   "minecraft_access.direction.west": "West",
+  "minecraft_access.gui.checkbox_checked": "%s checkbox checked",
+  "minecraft_access.gui.checkbox_unchecked": "%s checkbox unchecked",
   "minecraft_access.inventory_controls.Unknown": "Unknown",
   "minecraft_access.inventory_controls.direction_left": "Left",
   "minecraft_access.inventory_controls.direction_right": "Right",

--- a/common/src/main/resources/minecraft_access.mixins.json
+++ b/common/src/main/resources/minecraft_access.mixins.json
@@ -16,6 +16,7 @@
     "ButtonMixin",
     "ChatComponentAccessor",
     "ChatScreenMixin",
+    "CheckboxMixin",
     "ClientPacketListenerMixin",
     "CommandSuggestionsSuggestionsListMixin",
     "CreativeModeInventoryScreenAccessor",


### PR DESCRIPTION
[//]: # (This changelog will be part of the release notes)
[//]: # (Please keep anything that isn't part of the changelog above this line and delete unused headings)
[//]: # (Changelog entries should be formatted as unordered lists to ensure consistency when they are collated)

# Changelog

## Bug Fixes

- The checkbox widget is now narrated as "checkbox checked" or "checkbox unchecked", instead of "button"