### PR TITLE
Fix camera controls triggering twice

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/CameraControls.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/CameraControls.java
@@ -140,22 +140,22 @@ public class CameraControls {
 
         float rotateAngle = isLeftAltPressed ? config.modifiedRotatingAngle : config.normalRotatingAngle;
 
-        if (isUpKeyPressed) {
+        if (isUpKeyPressed && !isRightAltPressed) {
             anyFunctionTriggered = true;
             rotateCameraBy(rotateAngle, RotatingDirection.UP);
         }
 
-        if (isRightKeyPressed) {
+        if (isRightKeyPressed && !isRightAltPressed) {
             anyFunctionTriggered = true;
             rotateCameraBy(rotateAngle, RotatingDirection.RIGHT);
         }
 
-        if (isDownKeyPressed) {
+        if (isDownKeyPressed && !isRightAltPressed) {
             anyFunctionTriggered = true;
             rotateCameraBy(rotateAngle, RotatingDirection.DOWN);
         }
 
-        if (isLeftKeyPressed) {
+        if (isLeftKeyPressed && !isRightAltPressed) {
             anyFunctionTriggered = true;
             rotateCameraBy(rotateAngle, RotatingDirection.LEFT);
         }


### PR DESCRIPTION

[//]: # (This changelog will be part of the release notes)
[//]: # (Please keep anything that isn't part of the changelog above this line and delete unused headings)
[//]: # (Changelog entries should be formatted as unordered lists to ensure consistency when they are collated)

# Changelog

## Bug Fixes
- When using RIGHT ALT + CAMERA CONTROLS to snap to cardinal directions, the mod will no longer additionally move the camera in the direction of the pressed camera controls key
