### PR TITLE
Fix enchanting table

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/GroupGenerator.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/GroupGenerator.java
@@ -368,16 +368,21 @@ public class GroupGenerator {
                 Optional<Holder.Reference<Enchantment>> enchantment = Minecraft.getInstance().level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT).get(enchantmentId);
                 if (enchantment.isEmpty()) break;
 
-                StringBuilder clueText = new StringBuilder(Component.translatable("container.enchant.clue", Enchantment.getFullname(enchantment.get(), level)).getString());
+                StringBuilder clueText = new StringBuilder(Component.translatable("container.enchant.clue", Enchantment.getFullname(enchantment.get(), level)).getString()); // this breaks when using I18n.get() for some reason so Component.translatable() is being used instead
                 if (!PlayerUtils.isCreative()) {
                     if (Minecraft.getInstance().player.experienceLevel < requiredLevel) {
-                        clueText.append(Component.translatable("container.enchant.level.requirement", requiredLevel).getString());
+                        clueText.append(I18n.get("container.enchant.level.requirement", requiredLevel));
                     } else {
-                        String lapisCostText = cost == 1 ? Component.translatable("container.enchant.lapis.one").getString() : Component.translatable("container.enchant.lapis.many", cost).getString();
-                        if (enchantmentScreenHandler.getGoldCount() < cost) lapisCostText = "()" + I18n.get("minecraft_access.other.missing") + ") " + lapisCostText;
+                        String lapisCostText = cost == 1 ? I18n.get("container.enchant.lapis.one") : I18n.get("container.enchant.lapis.many", cost);
+                        if (enchantmentScreenHandler.getGoldCount() < cost) {
+                            lapisCostText = String.format("(%s) %s", I18n.get("minecraft_access.other.missing"), lapisCostText);
+                        }
                         clueText.append(lapisCostText);
-                        String xpCostText = cost == 1 ? Component.translatable("container.enchant.level.one").getString() : Component.translatable("container.enchant.level.many", cost).getString();
-                        if (PlayerUtils.getExperienceLevel() < cost) xpCostText = "()" + I18n.get("minecraft_access.other.missing") + ") " + xpCostText;
+
+                        String xpCostText = cost == 1 ? I18n.get("container.enchant.level.one") : I18n.get("container.enchant.level.many", cost);
+                        if (PlayerUtils.getExperienceLevel() < cost) {
+                            xpCostText = String.format("(%s) %s", I18n.get("minecraft_access.other.missing"), xpCostText);
+                        }
                         clueText.append(xpCostText);
                     }
                 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/GroupGenerator.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/GroupGenerator.java
@@ -7,6 +7,7 @@ import net.minecraft.client.gui.screens.inventory.*;
 import net.minecraft.client.gui.screens.recipebook.RecipeBookComponent;
 import net.minecraft.client.gui.screens.recipebook.RecipeButton;
 import net.minecraft.client.gui.screens.recipebook.RecipeCollection;
+import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
@@ -372,10 +373,12 @@ public class GroupGenerator {
                     if (Minecraft.getInstance().player.experienceLevel < requiredLevel) {
                         clueText.append(Component.translatable("container.enchant.level.requirement", requiredLevel).getString());
                     } else {
-                        MutableComponent lapisCostText = cost == 1 ? Component.translatable("container.enchant.lapis.one") : Component.translatable("container.enchant.lapis.many", cost);
-                        clueText.append(lapisCostText.getString());
-                        MutableComponent xpCostText = cost == 1 ? Component.translatable("container.enchant.level.one") : Component.translatable("container.enchant.level.many", cost);
-                        clueText.append(xpCostText.withStyle(ChatFormatting.GRAY).getString());
+                        String lapisCostText = cost == 1 ? Component.translatable("container.enchant.lapis.one").getString() : Component.translatable("container.enchant.lapis.many", cost).getString();
+                        if (enchantmentScreenHandler.getGoldCount() < cost) lapisCostText = "()" + I18n.get("minecraft_access.other.missing") + ") " + lapisCostText;
+                        clueText.append(lapisCostText);
+                        String xpCostText = cost == 1 ? Component.translatable("container.enchant.level.one").getString() : Component.translatable("container.enchant.level.many", cost).getString();
+                        if (PlayerUtils.getExperienceLevel() < cost) xpCostText = "()" + I18n.get("minecraft_access.other.missing") + ") " + xpCostText;
+                        clueText.append(xpCostText);
                     }
                 }
 

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/GroupGenerator.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/GroupGenerator.java
@@ -1,7 +1,6 @@
 package org.mcaccess.minecraftaccess.features.inventory_controls;
 
 import com.google.common.base.CaseFormat;
-import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.*;
 import net.minecraft.client.gui.screens.recipebook.RecipeBookComponent;
@@ -11,7 +10,6 @@ import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.*;

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/GroupGenerator.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/GroupGenerator.java
@@ -358,32 +358,28 @@ public class GroupGenerator {
         //<editor-fold desc="Group enchantment screen enchant buttons (EnchantScreen.java -->> render())">
         if (Minecraft.getInstance().player != null && Minecraft.getInstance().level != null
                 && screen.getMenu() instanceof EnchantmentMenu enchantmentScreenHandler) {
-            int i = enchantmentScreenHandler.getGoldCount();
-            for (int j = 0; j < 3; ++j) {
-                int k = enchantmentScreenHandler.costs[j];
-                int l = enchantmentScreenHandler.levelClue[j];
-                // copied from 1.21.3 EnchantmentScreen.render() L172
-                Optional<Holder.Reference<Enchantment>> optional = Minecraft.getInstance()
-                        .level
-                        .registryAccess()
-                        .lookupOrThrow(Registries.ENCHANTMENT)
-                        .get(l);
+            for (int i = 0; i < 3; i++) {
+                int enchantmentId = enchantmentScreenHandler.enchantClue[i];
+                int requiredLevel = enchantmentScreenHandler.costs[i];
+                int level = enchantmentScreenHandler.levelClue[i];
+                int cost = i + 1;
 
-                int m = j + 1;
-                if (optional.isEmpty()) break;
-                StringBuilder clueText = new StringBuilder(Component.translatable("container.enchant.clue", Enchantment.getFullname(optional.get(), l)).withStyle(ChatFormatting.WHITE).getString());
+                Optional<Holder.Reference<Enchantment>> enchantment = Minecraft.getInstance().level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT).get(enchantmentId);
+                if (enchantment.isEmpty()) break;
+
+                StringBuilder clueText = new StringBuilder(Component.translatable("container.enchant.clue", Enchantment.getFullname(enchantment.get(), level)).getString());
                 if (!PlayerUtils.isCreative()) {
-                    if (Minecraft.getInstance().player.experienceLevel < k) {
-                        clueText.append(Component.translatable("container.enchant.level.requirement", enchantmentScreenHandler.costs[j]).withStyle(ChatFormatting.RED).getString());
+                    if (Minecraft.getInstance().player.experienceLevel < requiredLevel) {
+                        clueText.append(Component.translatable("container.enchant.level.requirement", requiredLevel).getString());
                     } else {
-                        MutableComponent mutableText = m == 1 ? Component.translatable("container.enchant.lapis.one") : Component.translatable("container.enchant.lapis.many", m);
-                        clueText.append(mutableText.withStyle(i >= m ? ChatFormatting.GRAY : ChatFormatting.RED).getString());
-                        MutableComponent mutableText2 = m == 1 ? Component.translatable("container.enchant.level.one") : Component.translatable("container.enchant.level.many", m);
-                        clueText.append(mutableText2.withStyle(ChatFormatting.GRAY).getString());
+                        MutableComponent lapisCostText = cost == 1 ? Component.translatable("container.enchant.lapis.one") : Component.translatable("container.enchant.lapis.many", cost);
+                        clueText.append(lapisCostText.getString());
+                        MutableComponent xpCostText = cost == 1 ? Component.translatable("container.enchant.level.one") : Component.translatable("container.enchant.level.many", cost);
+                        clueText.append(xpCostText.withStyle(ChatFormatting.GRAY).getString());
                     }
                 }
 
-                enchantsGroup.slotItems.add(new SlotItem(80, 21 + 19 * j, clueText.toString()));
+                enchantsGroup.slotItems.add(new SlotItem(80, 21 + 19 * i, clueText.toString()));
             }
         }
         //</editor-fold>

--- a/common/src/main/resources/assets/minecraft_access/lang/en_us.json
+++ b/common/src/main/resources/assets/minecraft_access/lang/en_us.json
@@ -129,6 +129,7 @@
     "minecraft_access.other.end_of_list": "End of list",
     "minecraft_access.other.entity_with_equipments": "{entity} with {equipments}",
     "minecraft_access.other.facing_direction": "Facing %s",
+    "minecraft_access.other.missing": "Missing",
     "minecraft_access.other.negative": "negative %s",
     "minecraft_access.other.not_craftable": "Not Craftable",
     "minecraft_access.other.not_found": "Not Found",


### PR DESCRIPTION
closes #467 

Other than what I wrote in the changelog, I also refactored the enchanting table code to be more readable aka I gave all the variables normal names.

[//]: # (This changelog will be part of the user-facing release notes)
[//]: # (Please keep anything that isn't part of the changelog above this line and delete unused headings)
[//]: # (Changelog entries should be formatted as unordered lists to ensure consistency when they are collated)

# Changelog

## Feature Updates
- You will now be able to see when you don't have enough lapis or levels when enchanting
## Bug Fixes
- Fixed enchanting table UI reading wrong enchantments
