### PR TITLE
Only speak if window focused

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
@@ -171,7 +171,7 @@ public class MainClass {
 
     public static void speakWithNarrator(String text, boolean interrupt) {
         if (Strings.isNotEmpty(text) && Minecraft.getInstance().isWindowActive()) {
-            log.warn("The speaking of string %s with interrupt%s was suppressed".formatted(text, interrupt));
+            log.warn("The speaking of string \"{}\" with interrupt={} was suppressed", text, interrupt);
             return;
         }
         MainClass.interrupt = interrupt;

--- a/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
@@ -46,14 +46,14 @@ public class MainClass {
     public static void init() {
         Config.init();
 
-        String msg = "Initializing Minecraft Access: version " + Platform.getMod(MOD_ID).getVersion();
-        log.info(msg);
+        String startupMessage = "Initializing Minecraft Access: version " + Platform.getMod(MOD_ID).getVersion();
+        log.info(startupMessage);
 
         new AutoLibrarySetup().initialize();
 
         ScreenReaderController.refreshScreenReader();
         if (MainClass.getScreenReader() != null && MainClass.getScreenReader().isInitialized())
-            MainClass.getScreenReader().say(msg, true);
+            MainClass.getScreenReader().say(startupMessage, true);
 
         MainClass.inventoryControls = new InventoryControls();
         MainClass.biomeIndicator = new BiomeIndicator();
@@ -170,13 +170,11 @@ public class MainClass {
     }
 
     public static void speakWithNarrator(String text, boolean interrupt) {
+        if (Strings.isNotEmpty(text) && Minecraft.getInstance().isWindowActive()) {
+            log.warn("The speaking of string %s with interrupt%s was suppressed".formatted(text, interrupt));
+            return;
+        }
         MainClass.interrupt = interrupt;
         Minecraft.getInstance().getNarrator().sayNow(text);
-    }
-
-    public static void speakWithNarratorIfNotEmpty(String text, boolean interrupt) {
-        if (Strings.isNotEmpty(text)) {
-            speakWithNarrator(text, interrupt);
-        }
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
@@ -170,7 +170,7 @@ public class MainClass {
     }
 
     public static void speakWithNarrator(String text, boolean interrupt) {
-        if (Strings.isNotEmpty(text) && Minecraft.getInstance().isWindowActive()) {
+        if (Strings.isEmpty(text) || !Minecraft.getInstance().isWindowActive()) {
             log.warn("The speaking of string \"{}\" with interrupt={} was suppressed", text, interrupt);
             return;
         }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/InventoryControls.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/InventoryControls.java
@@ -146,7 +146,7 @@ public class InventoryControls {
                 String slotNarrationText = getCurrentSlotNarrationText();
                 if (!previousSlotText.equals(slotNarrationText)) {
                     previousSlotText = slotNarrationText;
-                    MainClass.speakWithNarratorIfNotEmpty(previousSlotText, true);
+                    MainClass.speakWithNarrator(previousSlotText, true);
                 }
             }
 

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/BookEditScreenMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/BookEditScreenMixin.java
@@ -221,7 +221,7 @@ public abstract class BookEditScreenMixin {
     @Inject(at = @At("RETURN"), method = "titleKeyPressed")
     private void speakWholeSigningTextWhileSigning(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
         String signingText = ((TextFieldHelperAccessor) this.titleEdit).getGetMessageFn().get();
-        MainClass.speakWithNarratorIfNotEmpty(signingText, true);
+        MainClass.speakWithNarrator(signingText, true);
     }
 
     @Unique
@@ -229,7 +229,7 @@ public abstract class BookEditScreenMixin {
         String pageText = minecraft_access$getPageText();
         int cursor = this.pageEdit.getCursorPos();
         String lineText = StringUtils.getLineTextWhereTheCursorIsLocatedIn(pageText, cursor);
-        MainClass.speakWithNarratorIfNotEmpty(lineText, true);
+        MainClass.speakWithNarrator(lineText, true);
     }
 
     @Unique
@@ -242,7 +242,7 @@ public abstract class BookEditScreenMixin {
         String pageText = minecraft_access$getPageText();
         MutableComponent pageIndicatorText = Component.translatable("book.pageIndicator", this.currentPage + 1, this.pages.size());
         pageText = "%s\n\n%s".formatted(pageText, pageIndicatorText.getString());
-        MainClass.speakWithNarratorIfNotEmpty(pageText, true);
+        MainClass.speakWithNarrator(pageText, true);
     }
 
     @Inject(at = @At("RETURN"), method = "<init>")

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
@@ -127,6 +127,6 @@ public class ChatScreenMixin {
      */
     @Inject(at = @At("TAIL"), method = "moveInHistory")
     private void speakSwitchedChatHistory(int index, CallbackInfo ci) {
-        MainClass.speakWithNarratorIfNotEmpty(this.input.getValue(), true);
+        MainClass.speakWithNarrator(this.input.getValue(), true);
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/CommandSuggestionsSuggestionsListMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/CommandSuggestionsSuggestionsListMixin.java
@@ -62,12 +62,12 @@ public class CommandSuggestionsSuggestionsListMixin {
     @Inject(at = @At("HEAD"), method = "useSuggestion")
     private void speakCompletion(CallbackInfo ci) {
         String selected = this.suggestionList.get(this.current).getText();
-        MainClass.speakWithNarratorIfNotEmpty(selected, true);
+        MainClass.speakWithNarrator(selected, true);
     }
 
     @Inject(at = @At("RETURN"), method = "<init>")
     private void speakFirstSuggestionWhenSuggestionsAreShown(CallbackInfo ci) {
         String first = mca$getSuggestionTextToSpeak();
-        MainClass.speakWithNarratorIfNotEmpty(first, true);
+        MainClass.speakWithNarrator(first, true);
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/EditBoxMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/EditBoxMixin.java
@@ -114,20 +114,20 @@ abstract class EditBoxMixin extends AbstractWidget {
             case GLFW.GLFW_KEY_LEFT: {
                 if (Screen.hasControlDown()) {
                     String hoveredText = this.mca$getCursorHoverOverText(this.getWordPosition(-1));
-                    MainClass.speakWithNarratorIfNotEmpty(hoveredText, true);
+                    MainClass.speakWithNarrator(hoveredText, true);
                 } else {
                     String hoveredText = this.mca$getCursorHoverOverText(this.getCursorPos(-1));
-                    MainClass.speakWithNarratorIfNotEmpty(hoveredText, true);
+                    MainClass.speakWithNarrator(hoveredText, true);
                 }
                 return;
             }
             case GLFW.GLFW_KEY_RIGHT: {
                 if (Screen.hasControlDown()) {
                     String hoveredText = this.mca$getCursorHoverOverText(this.getWordPosition(1));
-                    MainClass.speakWithNarratorIfNotEmpty(hoveredText, true);
+                    MainClass.speakWithNarrator(hoveredText, true);
                 } else {
                     String hoveredText = this.mca$getCursorHoverOverText(this.getCursorPos(1));
-                    MainClass.speakWithNarratorIfNotEmpty(hoveredText, true);
+                    MainClass.speakWithNarrator(hoveredText, true);
                 }
                 return;
             }
@@ -151,7 +151,7 @@ abstract class EditBoxMixin extends AbstractWidget {
             return;
         }
         String selectedText = this.getHighlighted();
-        MainClass.speakWithNarratorIfNotEmpty(selectedText, true);
+        MainClass.speakWithNarrator(selectedText, true);
     }
 
     @Inject(at = @At("HEAD"), method = "deleteChars")
@@ -163,7 +163,7 @@ abstract class EditBoxMixin extends AbstractWidget {
         boolean allTextAreSelected = this.highlightPos == 0;
         if (!allTextAreSelected) {
             String erasedText = mca$getCursorHoverOverText(cursorPos);
-            MainClass.speakWithNarratorIfNotEmpty(erasedText, true);
+            MainClass.speakWithNarrator(erasedText, true);
         }
     }
 

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
@@ -40,7 +40,7 @@ public class GuiMixin {
                 if (config.features.onlySpeakActionBarUpdates) {
                     minecraft_access$onlySpeakChangedParts(msg);
                 } else {
-                    MainClass.speakWithNarratorIfNotEmpty(msg, true);
+                    MainClass.speakWithNarrator(msg, true);
                 }
                 this.minecraft_access$previousActionBarContent = msg;
             }
@@ -53,7 +53,7 @@ public class GuiMixin {
         List<String> previousParts = Arrays.asList(StringUtils.splitToParts(this.minecraft_access$previousActionBarContent));
         parts.removeAll(previousParts);
         String toSpeak = String.join(", ", parts);
-        MainClass.speakWithNarratorIfNotEmpty(toSpeak, true);
+        MainClass.speakWithNarrator(toSpeak, true);
     }
 
     @Inject(method = "setTitle", at = @At("TAIL"))

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/TextFieldHelperMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/TextFieldHelperMixin.java
@@ -38,7 +38,7 @@ public abstract class TextFieldHelperMixin {
 
     @Inject(at = @At("TAIL"), method = "setCursorToEnd()V")
     public void speakTextOfSwitchedLine(CallbackInfo ci) {
-        MainClass.speakWithNarratorIfNotEmpty(this.getMessageFn.get(), true);
+        MainClass.speakWithNarrator(this.getMessageFn.get(), true);
     }
 
     @Inject(at = @At("HEAD"), method = "keyPressed")
@@ -52,20 +52,20 @@ public abstract class TextFieldHelperMixin {
             case GLFW.GLFW_KEY_LEFT: {
                 if (Screen.hasControlDown()) {
                     String hoveredText = this.getCursorHoveredOverText(getCursorPosByWordsWithOffset(-1));
-                    MainClass.speakWithNarratorIfNotEmpty(hoveredText, true);
+                    MainClass.speakWithNarrator(hoveredText, true);
                 } else {
                     String hoveredText = this.getCursorHoveredOverText(getCursorPosWithOffset(-1));
-                    MainClass.speakWithNarratorIfNotEmpty(hoveredText, true);
+                    MainClass.speakWithNarrator(hoveredText, true);
                 }
                 return;
             }
             case GLFW.GLFW_KEY_RIGHT: {
                 if (Screen.hasControlDown()) {
                     String hoveredText = this.getCursorHoveredOverText(getCursorPosByWordsWithOffset(1));
-                    MainClass.speakWithNarratorIfNotEmpty(hoveredText, true);
+                    MainClass.speakWithNarrator(hoveredText, true);
                 } else {
                     String hoveredText = this.getCursorHoveredOverText(getCursorPosWithOffset(1));
-                    MainClass.speakWithNarratorIfNotEmpty(hoveredText, true);
+                    MainClass.speakWithNarrator(hoveredText, true);
                 }
                 return;
             }
@@ -98,7 +98,7 @@ public abstract class TextFieldHelperMixin {
     @Inject(at = @At("RETURN"), method = "keyPressed")
     private void speakSelectedText(int keyCode, CallbackInfoReturnable<Boolean> cir) {
         String selectedText = this.getSelected(this.getMessageFn.get());
-        MainClass.speakWithNarratorIfNotEmpty(selectedText, true);
+        MainClass.speakWithNarrator(selectedText, true);
     }
 
     @Inject(at = @At("HEAD"), method = "removeCharsFromCursor")
@@ -110,7 +110,7 @@ public abstract class TextFieldHelperMixin {
         boolean allTextAreSelected = this.selectionPos == 0;
         if (!allTextAreSelected) {
             String erasedText = getCursorHoveredOverText(cursorPos);
-            MainClass.speakWithNarratorIfNotEmpty(erasedText, true);
+            MainClass.speakWithNarrator(erasedText, true);
         }
     }
 


### PR DESCRIPTION
Narration is now always suppressed if a string is empty and a warning is printed about it.

# Changelog

## Bug Fixes
- Narration of messages other than the initial initializing message are now suppressed when the game is not in focus