### PR TITLE
Ensure the advancements key is unbound on all platforms

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
@@ -40,7 +40,6 @@ public class MainClass {
     public static SpeakHeldItem speakHeldItem = null;
 
     public static boolean interrupt = true;
-    private static boolean alreadyDisabledAdvancementKey = false;
 
     /**
      * Initializes the mod
@@ -147,12 +146,12 @@ public class MainClass {
         accessMenu = new AccessMenu();
         fluidDetector = new FluidDetector();
         speakHeldItem = new SpeakHeldItem();
-        if (!alreadyDisabledAdvancementKey) {
-            Minecraft client = Minecraft.getInstance();
+
+        Minecraft client = Minecraft.getInstance();
+        if (client.options.keyAdvancements.same(KeyBindingsHandler.cameraControlsRight)) {
             client.options.keyAdvancements.setKey(InputConstants.UNKNOWN);
             client.options.save();
             client.options.load();
-            alreadyDisabledAdvancementKey = true;
             log.info("Unbound advancements key");
         }
     }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
@@ -81,12 +81,6 @@ public class MainClass {
 
         changeLogLevelBaseOnDebugConfig();
 
-        if (!MainClass.alreadyDisabledAdvancementKey) {
-            minecraftClient.options.keyAdvancements.setKey(InputConstants.getKey("key.keyboard.unknown"));
-            MainClass.alreadyDisabledAdvancementKey = true;
-            log.info("Unbound advancements key");
-        }
-
         if (config.menuFixEnabled) {
             MenuFix.update(minecraftClient);
         }
@@ -153,6 +147,14 @@ public class MainClass {
         accessMenu = new AccessMenu();
         fluidDetector = new FluidDetector();
         speakHeldItem = new SpeakHeldItem();
+        if (!alreadyDisabledAdvancementKey) {
+            Minecraft client = Minecraft.getInstance();
+            client.options.keyAdvancements.setKey(InputConstants.UNKNOWN);
+            client.options.save();
+            client.options.load();
+            alreadyDisabledAdvancementKey = true;
+            log.info("Unbound advancements key");
+        }
     }
 
     /**

--- a/common/src/main/java/org/mcaccess/minecraftaccess/compat/mixin/clothconfig/ClothConfigScreenMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/compat/mixin/clothconfig/ClothConfigScreenMixin.java
@@ -1,5 +1,6 @@
 package org.mcaccess.minecraftaccess.compat.mixin.clothconfig;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import me.shedaniel.clothconfig2.api.AbstractConfigEntry;
 import me.shedaniel.clothconfig2.gui.AbstractConfigScreen;
 import me.shedaniel.clothconfig2.gui.AbstractTabbedConfigScreen;
@@ -17,7 +18,6 @@ import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
-import org.lwjgl.glfw.GLFW;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.mixin.ScreenAccessor;
 import org.mcaccess.minecraftaccess.utils.ui.NavigationUtils;
@@ -88,7 +88,7 @@ abstract class ClothConfigScreenMixin extends AbstractTabbedConfigScreen {
      */
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        if (Screen.hasControlDown() && keyCode == GLFW.GLFW_KEY_TAB) {
+        if (Screen.hasControlDown() && keyCode == InputConstants.KEY_TAB) {
             mca$switchCategory(!Screen.hasShiftDown());
             return true;
         }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/MenuFix.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/MenuFix.java
@@ -1,5 +1,6 @@
 package org.mcaccess.minecraftaccess.features;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.DirectJoinServerScreen;
@@ -13,7 +14,6 @@ import net.minecraft.client.gui.screens.packs.PackSelectionScreen;
 import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
 import net.minecraft.client.gui.screens.worldselection.EditWorldScreen;
 import net.minecraft.client.gui.screens.worldselection.SelectWorldScreen;
-import org.lwjgl.glfw.GLFW;
 import org.mcaccess.minecraftaccess.utils.system.KeyUtils;
 import org.mcaccess.minecraftaccess.utils.system.MouseUtils;
 
@@ -75,7 +75,7 @@ public class MenuFix {
             }
 
             boolean isLeftAltPressed = KeyUtils.isLeftAltPressed();
-            boolean isRPressed = KeyUtils.isAnyPressed(GLFW.GLFW_KEY_R);
+            boolean isRPressed = KeyUtils.isAnyPressed(InputConstants.KEY_R);
             if (isLeftAltPressed && isRPressed)
                 moveMouseCursor(minecraftClient);
         }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/PositionNarrator.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/PositionNarrator.java
@@ -1,10 +1,9 @@
 package org.mcaccess.minecraftaccess.features;
 
-import org.mcaccess.minecraftaccess.Config;
+import com.mojang.blaze3d.platform.InputConstants;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.client.Minecraft;
-import org.lwjgl.glfw.GLFW;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.utils.KeyBindingsHandler;
 import org.mcaccess.minecraftaccess.utils.condition.Keystroke;
@@ -23,9 +22,9 @@ import org.mcaccess.minecraftaccess.utils.system.KeyUtils;
 public class PositionNarrator {
     @Getter
     private static final PositionNarrator instance;
-    public static Keystroke KeyX = new Keystroke(() -> KeyUtils.isAnyPressed(GLFW.GLFW_KEY_X));
-    public static Keystroke KeyC = new Keystroke(() -> KeyUtils.isAnyPressed(GLFW.GLFW_KEY_C));
-    public static Keystroke KeyZ = new Keystroke(() -> KeyUtils.isAnyPressed(GLFW.GLFW_KEY_Z));
+    public static Keystroke KeyX = new Keystroke(() -> KeyUtils.isAnyPressed(InputConstants.KEY_X));
+    public static Keystroke KeyC = new Keystroke(() -> KeyUtils.isAnyPressed(InputConstants.KEY_C));
+    public static Keystroke KeyZ = new Keystroke(() -> KeyUtils.isAnyPressed(InputConstants.KEY_Z));
     public static Keystroke positionNarrationKey;
 
     static {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/access_menu/AccessMenu.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/access_menu/AccessMenu.java
@@ -12,7 +12,6 @@ import net.minecraft.core.Holder;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
-import org.lwjgl.glfw.GLFW;
 import org.mcaccess.minecraftaccess.Config;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.features.BiomeIndicator;
@@ -116,7 +115,7 @@ public class AccessMenu {
 
         if (minecraftClient.screen instanceof GameModeSwitcherScreen) {
             gameModeSwitcherActive = true;
-        } else if (!KeyUtils.isAnyPressed(GLFW.GLFW_KEY_F4)) {
+        } else if (!KeyUtils.isAnyPressed(InputConstants.KEY_F4)) {
             gameModeSwitcherActive = false;
         }
     }
@@ -127,7 +126,7 @@ public class AccessMenu {
         // for the little performance improvement, will not use KeyUtils here.
         long handle = minecraftClient.getWindow().getWindow();
         Stream.of(FUNCTIONS)
-                .filter(f -> InputConstants.isKeyDown(handle, f.number + GLFW.GLFW_KEY_0))
+                .filter(f -> InputConstants.isKeyDown(handle, f.number + InputConstants.KEY_0))
                 .findFirst()
                 .ifPresent(f -> {
                     if (functionIntervals[f.number].isReady()) {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/InventoryControls.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/InventoryControls.java
@@ -1,5 +1,6 @@
 package org.mcaccess.minecraftaccess.features.inventory_controls;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.EditBox;
@@ -21,7 +22,6 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.crafting.ExtendedRecipeBookCategory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.lwjgl.glfw.GLFW;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.Config;
 import org.mcaccess.minecraftaccess.mixin.*;
@@ -184,7 +184,7 @@ public class InventoryControls {
         boolean isToggleCraftableKeyPressed = KeyUtils.isAnyPressed(kbh.inventoryControlsToggleCraftableKey);
         boolean isLeftShiftPressed = KeyUtils.isLeftShiftPressed();
         boolean isEnterPressed = KeyUtils.isEnterPressed();
-        boolean isTPressed = KeyUtils.isAnyPressed(GLFW.GLFW_KEY_T);
+        boolean isTPressed = KeyUtils.isAnyPressed(InputConstants.KEY_T);
         boolean disableInputForSearchBox = false;
 
         //<editor-fold desc="When using a search box">

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/BookEditScreenMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/BookEditScreenMixin.java
@@ -1,5 +1,6 @@
 package org.mcaccess.minecraftaccess.mixin;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
@@ -10,7 +11,6 @@ import net.minecraft.client.gui.screens.inventory.PageButton;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import org.lwjgl.glfw.GLFW;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.utils.StringUtils;
 import org.mcaccess.minecraftaccess.utils.condition.Keystroke;
@@ -68,7 +68,7 @@ public abstract class BookEditScreenMixin {
     @Final
     private TextFieldHelper titleEdit;
     @Unique
-    private static final Keystroke minecraft_access$tabKey = new Keystroke(() -> KeyUtils.isAnyPressed(GLFW.GLFW_KEY_TAB));
+    private static final Keystroke minecraft_access$tabKey = new Keystroke(() -> KeyUtils.isAnyPressed(InputConstants.KEY_TAB));
     @Unique
     private static final Keystroke minecraft_access$spaceKey = new Keystroke(KeyUtils::isSpacePressed);
 
@@ -174,42 +174,42 @@ public abstract class BookEditScreenMixin {
         }
 
         switch (keyCode) {
-            case GLFW.GLFW_KEY_ENTER:
-            case GLFW.GLFW_KEY_KP_ENTER: {
+            case InputConstants.KEY_RETURN:
+            case InputConstants.KEY_NUMPADENTER: {
                 this.pageEdit.insertText("\n");
                 cir.setReturnValue(true);
                 return;
             }
-            case GLFW.GLFW_KEY_UP: {
+            case InputConstants.KEY_UP: {
                 this.keyUp();
                 minecraft_access$speakCurrentLineContent();
                 cir.setReturnValue(true);
                 return;
             }
-            case GLFW.GLFW_KEY_DOWN: {
+            case  InputConstants.KEY_DOWN: {
                 this.keyDown();
                 minecraft_access$speakCurrentLineContent();
                 cir.setReturnValue(true);
                 return;
             }
-            case GLFW.GLFW_KEY_PAGE_UP: {
+            case InputConstants.KEY_PAGEUP: {
                 this.backButton.onPress();
                 minecraft_access$speakCurrentPageContent();
                 cir.setReturnValue(true);
                 return;
             }
-            case GLFW.GLFW_KEY_PAGE_DOWN: {
+            case InputConstants.KEY_PAGEDOWN: {
                 this.forwardButton.onPress();
                 minecraft_access$speakCurrentPageContent();
                 cir.setReturnValue(true);
                 return;
             }
-            case GLFW.GLFW_KEY_HOME: {
+            case InputConstants.KEY_HOME: {
                 this.keyHome();
                 cir.setReturnValue(true);
                 return;
             }
-            case GLFW.GLFW_KEY_END: {
+            case InputConstants.KEY_END: {
                 this.keyEnd();
                 cir.setReturnValue(true);
                 return;

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/BookViewScreenMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/BookViewScreenMixin.java
@@ -1,12 +1,12 @@
 package org.mcaccess.minecraftaccess.mixin;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.BookViewScreen;
 import net.minecraft.client.gui.screens.inventory.PageButton;
 import net.minecraft.network.chat.Component;
-import org.lwjgl.glfw.GLFW;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.utils.system.KeyUtils;
 import org.spongepowered.asm.mixin.Mixin;
@@ -36,7 +36,7 @@ public class BookViewScreenMixin {
         if (minecraftClient == null) return;
         if (minecraftClient.screen == null) return;
 
-        boolean isRPressed = KeyUtils.isAnyPressed(GLFW.GLFW_KEY_R);
+        boolean isRPressed = KeyUtils.isAnyPressed(InputConstants.KEY_R);
 
         // Repeat current page content and un-focus next and previous page buttons
         if (Screen.hasAltDown() && isRPressed) {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
@@ -8,7 +8,6 @@ import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
-import org.lwjgl.glfw.GLFW;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -71,18 +70,18 @@ public class ChatScreenMixin {
         int numMessages = ((ChatComponentAccessor) Minecraft.getInstance().gui.getChat()).getAllMessages().size();
         int newChatMessagePage = minecraft_access$currentChatMessagePage;
         if (Screen.hasAltDown()) {
-            if (InputConstants.isKeyDown(window, InputConstants.KEY_GRAVE) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_MULTIPLY)) {
+            if (InputConstants.isKeyDown(window, InputConstants.KEY_GRAVE) || InputConstants.isKeyDown(window, InputConstants.KEY_MULTIPLY)) {
                 if (Screen.hasControlDown()) {
                     newChatMessagePage = numMessages / 10;
                 } else {
                     newChatMessagePage = 0;
                 }
-            } else if (InputConstants.isKeyDown(window, InputConstants.KEY_EQUALS) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_ADD)) {
+            } else if (InputConstants.isKeyDown(window, InputConstants.KEY_EQUALS) || InputConstants.isKeyDown(window, InputConstants.KEY_ADD)) {
                 newChatMessagePage -= 1;
                 if (Screen.hasControlDown()) {
                     newChatMessagePage -= 4;
                 }
-            } else if (InputConstants.isKeyDown(window, InputConstants.KEY_MINUS) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_KP_SUBTRACT)) {
+            } else if (InputConstants.isKeyDown(window, InputConstants.KEY_MINUS) || InputConstants.isKeyDown(window, InputConstants.KEY_MINUS)) {
                 newChatMessagePage += 1;
                 if (Screen.hasControlDown()) {
                     newChatMessagePage += 4;
@@ -97,12 +96,12 @@ public class ChatScreenMixin {
             }
 
             for (int i = 1; i <= 9; i++) {
-                if (keyCode == GLFW.GLFW_KEY_0 + i || keyCode == GLFW.GLFW_KEY_KP_0 + i) {
+                if (keyCode == InputConstants.KEY_0 + i || keyCode == InputConstants.KEY_NUMPAD0 + i) {
                     minecraft_access$speakPreviousChatAtIndex(i + minecraft_access$currentChatMessagePage * 10 - 1);
                     return true;
                 }
             }
-            if (InputConstants.isKeyDown(window, GLFW.GLFW_KEY_0) || InputConstants.isKeyDown(window, InputConstants.KEY_NUMPAD0)) {
+            if (InputConstants.isKeyDown(window, InputConstants.KEY_0) || InputConstants.isKeyDown(window, InputConstants.KEY_NUMPAD0)) {
                 minecraft_access$speakPreviousChatAtIndex(10 + minecraft_access$currentChatMessagePage * 10 - 1);
             }
         }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/EditBoxMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/EditBoxMixin.java
@@ -1,5 +1,6 @@
 package org.mcaccess.minecraftaccess.mixin;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.narration.NarratedElementType;
@@ -9,7 +10,6 @@ import net.minecraft.client.gui.screens.inventory.CommandBlockEditScreen;
 import net.minecraft.network.chat.Component;
 import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.Nullable;
-import org.lwjgl.glfw.GLFW;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -111,7 +111,7 @@ abstract class EditBoxMixin extends AbstractWidget {
         }
 
         switch (keyCode) {
-            case GLFW.GLFW_KEY_LEFT: {
+            case InputConstants.KEY_LEFT: {
                 if (Screen.hasControlDown()) {
                     String hoveredText = this.mca$getCursorHoverOverText(this.getWordPosition(-1));
                     MainClass.speakWithNarrator(hoveredText, true);
@@ -121,7 +121,7 @@ abstract class EditBoxMixin extends AbstractWidget {
                 }
                 return;
             }
-            case GLFW.GLFW_KEY_RIGHT: {
+            case InputConstants.KEY_RIGHT: {
                 if (Screen.hasControlDown()) {
                     String hoveredText = this.mca$getCursorHoverOverText(this.getWordPosition(1));
                     MainClass.speakWithNarrator(hoveredText, true);
@@ -131,13 +131,13 @@ abstract class EditBoxMixin extends AbstractWidget {
                 }
                 return;
             }
-            case GLFW.GLFW_KEY_HOME: {
+            case InputConstants.KEY_HOME: {
                 if (Strings.isNotEmpty(this.value)) {
                     MainClass.speakWithNarrator(this.value.substring(0, 1), true);
                 }
                 return;
             }
-            case GLFW.GLFW_KEY_END: {
+            case InputConstants.KEY_END: {
                 if (Strings.isNotEmpty(this.value)) {
                     MainClass.speakWithNarrator(this.value.substring(this.value.length() - 1), true);
                 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/TextFieldHelperMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/TextFieldHelperMixin.java
@@ -1,5 +1,6 @@
 package org.mcaccess.minecraftaccess.mixin;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.Util;
 import net.minecraft.client.StringSplitter;
 import net.minecraft.client.gui.font.TextFieldHelper;
@@ -7,7 +8,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractSignEditScreen;
 import net.minecraft.client.gui.screens.inventory.BookEditScreen;
 import org.apache.logging.log4j.util.Strings;
-import org.lwjgl.glfw.GLFW;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -49,7 +49,7 @@ public abstract class TextFieldHelperMixin {
         }
 
         switch (keyCode) {
-            case GLFW.GLFW_KEY_LEFT: {
+            case InputConstants.KEY_LEFT: {
                 if (Screen.hasControlDown()) {
                     String hoveredText = this.getCursorHoveredOverText(getCursorPosByWordsWithOffset(-1));
                     MainClass.speakWithNarrator(hoveredText, true);
@@ -59,7 +59,7 @@ public abstract class TextFieldHelperMixin {
                 }
                 return;
             }
-            case GLFW.GLFW_KEY_RIGHT: {
+            case InputConstants.KEY_RIGHT: {
                 if (Screen.hasControlDown()) {
                     String hoveredText = this.getCursorHoveredOverText(getCursorPosByWordsWithOffset(1));
                     MainClass.speakWithNarrator(hoveredText, true);
@@ -69,14 +69,14 @@ public abstract class TextFieldHelperMixin {
                 }
                 return;
             }
-            case GLFW.GLFW_KEY_HOME: {
+            case InputConstants.KEY_HOME: {
                 String text = this.getMessageFn.get();
                 if (Strings.isNotEmpty(text)) {
                     MainClass.speakWithNarrator(text.substring(0, 1), true);
                 }
                 return;
             }
-            case GLFW.GLFW_KEY_END: {
+            case InputConstants.KEY_END: {
                 String text = this.getMessageFn.get();
                 if (Strings.isNotEmpty(text)) {
                     MainClass.speakWithNarrator(text.substring(text.length() - 1), true);

--- a/common/src/main/java/org/mcaccess/minecraftaccess/utils/KeyBindingsHandler.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/utils/KeyBindingsHandler.java
@@ -2,7 +2,6 @@ package org.mcaccess.minecraftaccess.utils;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
-import org.lwjgl.glfw.GLFW;
 
 import java.util.Set;
 
@@ -78,224 +77,224 @@ public class KeyBindingsHandler {
         inventoryControlsGroupKey = new KeyMapping(
                 "minecraft_access.keys.inventory_controls.change_group_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_C,
+                InputConstants.KEY_C,
                 INVENTORY_CONTROLS_TRANSLATION_KEY
         );
 
         inventoryControlsUpKey = new KeyMapping(
                 "minecraft_access.keys.inventory_controls.up_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_I,
+                InputConstants.KEY_I,
                 INVENTORY_CONTROLS_TRANSLATION_KEY
         );
 
         inventoryControlsRightKey = new KeyMapping(
                 "minecraft_access.keys.inventory_controls.right_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_L,
+                InputConstants.KEY_L,
                 INVENTORY_CONTROLS_TRANSLATION_KEY
         );
 
         inventoryControlsDownKey = new KeyMapping(
                 "minecraft_access.keys.inventory_controls.down_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_K,
+                InputConstants.KEY_K,
                 INVENTORY_CONTROLS_TRANSLATION_KEY
         );
 
         inventoryControlsLeftKey = new KeyMapping(
                 "minecraft_access.keys.inventory_controls.left_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_J,
+                InputConstants.KEY_J,
                 INVENTORY_CONTROLS_TRANSLATION_KEY
         );
 
         inventoryControlsSwitchTabKey = new KeyMapping(
                 "minecraft_access.keys.inventory_controls.switch_tabs_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_V,
+                InputConstants.KEY_V,
                 INVENTORY_CONTROLS_TRANSLATION_KEY
         );
 
         inventoryControlsToggleCraftableKey = new KeyMapping(
                 "minecraft_access.keys.inventory_controls.toggle_craftable_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_R,
+                InputConstants.KEY_R,
                 INVENTORY_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsUp = new KeyMapping(
                 "minecraft_access.keys.camera_controls.up_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_I,
+                InputConstants.KEY_I,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsRight = new KeyMapping(
                 "minecraft_access.keys.camera_controls.right_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_L,
+                InputConstants.KEY_L,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsDown = new KeyMapping(
                 "minecraft_access.keys.camera_controls.down_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_K,
+                InputConstants.KEY_K,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsLeft = new KeyMapping(
                 "minecraft_access.keys.camera_controls.left_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_J,
+                InputConstants.KEY_J,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsAlternateUp = new KeyMapping(
                 "minecraft_access.keys.camera_controls.alternate_up_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_KP_8,
+                InputConstants.KEY_NUMPAD8,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsAlternateRight = new KeyMapping(
                 "minecraft_access.keys.camera_controls.alternate_right_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_KP_6,
+                InputConstants.KEY_NUMPAD6,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsAlternateDown = new KeyMapping(
                 "minecraft_access.keys.camera_controls.alternate_down_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_KP_2,
+                InputConstants.KEY_NUMPAD2,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsAlternateLeft = new KeyMapping(
                 "minecraft_access.keys.camera_controls.alternate_left_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_KP_4,
+                InputConstants.KEY_NUMPAD4,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsNorth = new KeyMapping(
                 "minecraft_access.keys.camera_controls.north_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_KP_7,
+                InputConstants.KEY_NUMPAD7,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsEast = new KeyMapping(
                 "minecraft_access.keys.camera_controls.east_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_KP_9,
+                InputConstants.KEY_NUMPAD9,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsWest = new KeyMapping(
                 "minecraft_access.keys.camera_controls.west_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_KP_1,
+                InputConstants.KEY_NUMPAD1,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsSouth = new KeyMapping(
                 "minecraft_access.keys.camera_controls.south_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_KP_3,
+                InputConstants.KEY_NUMPAD3,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsStraightUp = new KeyMapping(
                 "minecraft_access.keys.camera_controls.straight_up_camera_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_KP_0,
+                InputConstants.KEY_NUMPAD0,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsStraightDown = new KeyMapping(
                 "minecraft_access.keys.camera_controls.straight_down_camera_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_KP_DECIMAL,
+                InputConstants.KEY_NUMPADCOMMA,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         cameraControlsCenterCamera = new KeyMapping(
                 "minecraft_access.keys.camera_controls.center_camera_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_KP_5,
+                InputConstants.KEY_NUMPAD5,
                 CAMERA_CONTROLS_TRANSLATION_KEY
         );
 
         mouseSimulationLeftMouseKey = new KeyMapping(
                 "minecraft_access.keys.mouse_simulation.left_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_LEFT_BRACKET,
+                InputConstants.KEY_LBRACKET,
                 MOUSE_SIMULATION_KEY
         );
 
         mouseSimulationRightMouseKey = new KeyMapping(
                 "minecraft_access.keys.mouse_simulation.right_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_RIGHT_BRACKET,
+                InputConstants.KEY_RBRACKET,
                 MOUSE_SIMULATION_KEY
         );
 
         mouseSimulationMiddleMouseKey = new KeyMapping(
                 "minecraft_access.keys.mouse_simulation.middle_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_BACKSLASH,
+                InputConstants.KEY_BACKSLASH,
                 MOUSE_SIMULATION_KEY
         );
 
         mouseSimulationScrollUpKey = new KeyMapping(
                 "minecraft_access.keys.mouse_simulation.scroll_up_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_SEMICOLON,
+                InputConstants.KEY_SEMICOLON,
                 MOUSE_SIMULATION_KEY
         );
 
         mouseSimulationScrollDownKey = new KeyMapping(
                 "minecraft_access.keys.mouse_simulation.scroll_down_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_APOSTROPHE,
+                InputConstants.KEY_APOSTROPHE,
                 MOUSE_SIMULATION_KEY
         );
 
         speakPlayerStatusKey = new KeyMapping(
                 "minecraft_access.keys.other.player_status_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_R,
+                InputConstants.KEY_R,
                 OTHER_GROUP_TRANSLATION_KEY
         );
 
         lockingHandlerKey = new KeyMapping(
                 "minecraft_access.keys.other.locking_handler_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_Y,
+                InputConstants.KEY_Y,
                 OTHER_GROUP_TRANSLATION_KEY
         );
 
         positionNarrationKey = new KeyMapping(
                 "minecraft_access.keys.other.player_position_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_G,
+                InputConstants.KEY_G,
                 OTHER_GROUP_TRANSLATION_KEY
         );
 
         accessMenuKey = new KeyMapping(
                 "minecraft_access.keys.other.access_menu_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_F4,
+                InputConstants.KEY_F4,
                 OTHER_GROUP_TRANSLATION_KEY
         );
 
         narrateTarget = new KeyMapping(
                 "minecraft_access.access_menu.gui.button.block_and_fluid_target_info",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_B,
+                InputConstants.KEY_B,
                 OTHER_GROUP_TRANSLATION_KEY
         );
 
@@ -365,35 +364,35 @@ public class KeyBindingsHandler {
         directionNarrationKey = new KeyMapping(
                 "minecraft_access.keys.other.facing_direction_key_name",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_H,
+                InputConstants.KEY_H,
                 OTHER_GROUP_TRANSLATION_KEY
         );
 
         objectTrackerNextItem = new KeyMapping(
                 "minecraft_access.keys.object_tracker.next_item",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_PAGE_DOWN,
+                InputConstants.KEY_PAGEDOWN,
                 OBJECT_TRACKER_KEY
         );
 
         objectTrackerPreviousItem = new KeyMapping(
                 "minecraft_access.keys.object_tracker.previous_item",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_PAGE_UP,
+                InputConstants.KEY_PAGEUP,
                 OBJECT_TRACKER_KEY
         );
 
         objectTrackerNarrateCurrentObject = new KeyMapping(
                 "minecraft_access.keys.object_tracker.narrate_current_object",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_HOME,
+                InputConstants.KEY_HOME,
                 OBJECT_TRACKER_KEY
         );
 
         targetNearestObject = new KeyMapping(
                 "minecraft_access.keys.object_tracker.target_nearest",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_END,
+                InputConstants.KEY_END,
                 OBJECT_TRACKER_KEY
         );
     }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/utils/system/KeyUtils.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/utils/system/KeyUtils.java
@@ -3,7 +3,6 @@ package org.mcaccess.minecraftaccess.utils.system;
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
-import org.lwjgl.glfw.GLFW;
 import org.mcaccess.minecraftaccess.mixin.KeyMappingAccessor;
 
 import java.util.Arrays;
@@ -22,7 +21,7 @@ public class KeyUtils {
     }
 
     /**
-     * Pass any number of key codes (they are registered as constants: GLFW.GLFW_*)
+     * Pass any number of key codes (they are registered as constants: InputConstants.KEY_*)
      */
     public static boolean isAnyPressed(int... keyCodes) {
         Minecraft minecraftClient = Minecraft.getInstance();
@@ -58,27 +57,27 @@ public class KeyUtils {
     }
 
     public static boolean isF3Pressed() {
-        return isAnyPressed(GLFW.GLFW_KEY_F3);
+        return isAnyPressed(InputConstants.KEY_F3);
     }
 
     public static boolean isLeftShiftPressed() {
-        return isAnyPressed(GLFW.GLFW_KEY_LEFT_SHIFT);
+        return isAnyPressed(InputConstants.KEY_LSHIFT);
     }
 
     public static boolean isLeftAltPressed() {
-        return isAnyPressed(GLFW.GLFW_KEY_LEFT_ALT);
+        return isAnyPressed(InputConstants.KEY_LALT);
     }
 
     public static boolean isRightAltPressed() {
-        return isAnyPressed(GLFW.GLFW_KEY_RIGHT_ALT);
+        return isAnyPressed(InputConstants.KEY_RALT);
     }
 
     public static boolean isEnterPressed() {
-        return isAnyPressed(GLFW.GLFW_KEY_ENTER, GLFW.GLFW_KEY_KP_ENTER);
+        return isAnyPressed(InputConstants.KEY_RETURN, InputConstants.KEY_NUMPADENTER);
     }
 
     public static boolean isSpacePressed() {
-        return isAnyPressed(GLFW.GLFW_KEY_SPACE);
+        return isAnyPressed(InputConstants.KEY_SPACE);
     }
 
     public static boolean isSpaceOrEnterPressed() {


### PR DESCRIPTION
Fixes #376



[//]: # (This changelog will be part of the user-facing release notes)
[//]: # (Please keep anything that isn't part of the changelog above this line and delete unused headings)
[//]: # (Changelog entries should be formatted as unordered lists to ensure consistency when they are collated)

# Changelog

## Bug Fixes
- Resolves a bug where the advancements key could remain bound preventing usage of the camera controls