### PR TITLE
Fix Almost all gradle deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,6 @@ allprojects {
     apply plugin: "java"
     apply plugin: libs.plugins.architecturyPlugin.get().pluginId
     apply plugin: "maven-publish"
-    apply plugin: "base"
 
     base.archivesName = 'minecraft-access'
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,9 +75,7 @@ allprojects {
     apply plugin: "maven-publish"
     apply plugin: "base"
 
-    base {
-        archivesName.set("minecraft-access")
-    }
+    base.archivesName = 'minecraft-access'
 
     group = "org.mcaccess.minecraftaccess"
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.architecturyPlugin)
     alias(libs.plugins.architecturyLoom) apply false
     alias(libs.plugins.gitVersion)
+    id 'base'
 }
 
 def git = versionDetails()
@@ -73,8 +74,12 @@ allprojects {
     apply plugin: "java"
     apply plugin: libs.plugins.architecturyPlugin.get().pluginId
     apply plugin: "maven-publish"
+    apply plugin: "base"
 
-    archivesBaseName = "minecraft-access"
+    base {
+        archivesName.set("minecraft-access")
+    }
+
     group = "org.mcaccess.minecraftaccess"
 
     tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.architecturyPlugin)
     alias(libs.plugins.architecturyLoom) apply false
     alias(libs.plugins.gitVersion)
-    id 'base'
 }
 
 def git = versionDetails()

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -33,15 +33,16 @@ dependencies {
 
     modImplementation libs.modMenu
 
-    common(project(path: ":common", configuration: "namedElements")) { transitive false }
-    shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) { transitive false }
+    common(project(path: ":common", configuration: "namedElements")) { transitive = false }
+    shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) { transitive = false }
 }
 
 processResources {
-    inputs.property "version", project.version
+    def modVersion = project.version.toString()
+    inputs.property "version", modVersion
 
     filesMatching("fabric.mod.json") {
-        expand version: project.version,
+        expand version: modVersion,
                 fabric_loader_version: libs.fabricLoader.get().version,
                 fabric_api_version: libs.fabricApi.get().version,
                 architectury_api_version: libs.architecturyApiFabric.get().version,

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -28,15 +28,16 @@ dependencies {
     modImplementation libs.clothConfigNeoForge
     include libs.clothConfigNeoForge
 
-    common(project(path: ":common", configuration: "namedElements")) { transitive false }
-    shadowCommon(project(path: ":common", configuration: "transformProductionNeoForge")) { transitive false }
+    common(project(path: ":common", configuration: "namedElements")) { transitive = false }
+    shadowCommon(project(path: ":common", configuration: "transformProductionNeoForge")) { transitive = false }
 }
 
 processResources {
-    inputs.property "version", project.version
+    def modVersion = project.version.toString()
+    inputs.property "version", modVersion
 
     filesMatching("META-INF/neoforge.mods.toml") {
-        expand version: project.version,
+        expand version: modVersion,
                 neoforge_version: libs.neoForge.get().version,
                 architectury_api_version: libs.architecturyApiNeoForge.get().version,
                 jade_neoforge_version: libs.jadeNeoForge.get().version,


### PR DESCRIPTION
Fixes all of our gradle deprecation warnings. [One warning remains](https://scans.gradle.com/s/irq47kzoi4u3o/deprecations?expanded=WyIzIl0) on both fabric and Neo for `transformProduction`, but the best I can tell, those aren't our tasks and they come from an external plugin like Architectury.
Closes #472 