### PR TITLE
Override narrateMessage in GameNarrator, not the say* methods

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
@@ -7,7 +7,6 @@ import dev.architectury.platform.Platform;
 import dev.architectury.registry.client.keymappings.KeyMappingRegistry;
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.client.KeyMapping;
-import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.NarratorStatus;
 import net.minecraft.client.player.LocalPlayer;

--- a/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
@@ -7,7 +7,9 @@ import dev.architectury.platform.Platform;
 import dev.architectury.registry.client.keymappings.KeyMappingRegistry;
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.NarratorStatus;
 import net.minecraft.client.player.LocalPlayer;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
@@ -17,6 +19,7 @@ import org.mcaccess.minecraftaccess.features.access_menu.AccessMenu;
 import org.mcaccess.minecraftaccess.features.inventory_controls.InventoryControls;
 import org.mcaccess.minecraftaccess.features.point_of_interest.POIMarking;
 import org.mcaccess.minecraftaccess.features.read_crosshair.ReadCrosshair;
+import org.mcaccess.minecraftaccess.mixin.GameNarratorAccessor;
 import org.mcaccess.minecraftaccess.screen_reader.ScreenReaderController;
 import org.mcaccess.minecraftaccess.screen_reader.ScreenReaderInterface;
 import org.mcaccess.minecraftaccess.utils.KeyBindingsHandler;
@@ -38,8 +41,6 @@ public class MainClass {
     public static AccessMenu accessMenu = null;
     public static FluidDetector fluidDetector = null;
     public static SpeakHeldItem speakHeldItem = null;
-
-    public static boolean interrupt = true;
 
     /**
      * Initializes the mod
@@ -183,7 +184,8 @@ public class MainClass {
             log.warn("The speaking of string \"{}\" with interrupt={} was suppressed", text, interrupt);
             return;
         }
-        MainClass.interrupt = interrupt;
-        Minecraft.getInstance().getNarrator().sayNow(text);
+        if (Minecraft.getInstance().options.narrator().get() != NarratorStatus.OFF) {
+            ((GameNarratorAccessor) Minecraft.getInstance().getNarrator()).invokeNarrateMessage(text, interrupt);
+        }
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorAccessor.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorAccessor.java
@@ -1,0 +1,11 @@
+package org.mcaccess.minecraftaccess.mixin;
+
+import net.minecraft.client.GameNarrator;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(GameNarrator.class)
+public interface GameNarratorAccessor {
+    @Invoker("narrateMessage")
+    void invokeNarrateMessage(String text, boolean interrupt);
+}

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorAccessor.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorAccessor.java
@@ -6,6 +6,6 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(GameNarrator.class)
 public interface GameNarratorAccessor {
-    @Invoker("narrateMessage")
+    @Invoker
     void invokeNarrateMessage(String text, boolean interrupt);
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorMixin.java
@@ -2,7 +2,6 @@ package org.mcaccess.minecraftaccess.mixin;
 
 import com.mojang.text2speech.Narrator;
 import net.minecraft.client.GameNarrator;
-import net.minecraft.client.Minecraft;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.utils.NarratorDummy;
 import org.spongepowered.asm.mixin.Mixin;

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorMixin.java
@@ -3,9 +3,6 @@ package org.mcaccess.minecraftaccess.mixin;
 import com.mojang.text2speech.Narrator;
 import net.minecraft.client.GameNarrator;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.NarratorStatus;
-import net.minecraft.client.gui.components.toasts.SystemToast;
-import net.minecraft.client.gui.components.toasts.ToastManager;
 import net.minecraft.network.chat.Component;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.utils.NarratorDummy;
@@ -23,49 +20,12 @@ public class GameNarratorMixin {
         return new NarratorDummy();
     }
 
-    @Inject(at = @At("HEAD"), method = "sayNow(Ljava/lang/String;)V", cancellable = true)
-    private void sayNow(String text, CallbackInfo callbackInfo) {
+    @Inject(at = @At("HEAD"), method = "narrateMessage", cancellable = true)
+    private void narrateMessage(String text, boolean interrupt, CallbackInfo callbackInfo) {
         if (MainClass.getScreenReader() == null || !MainClass.getScreenReader().isInitialized()) {
             return;
         }
-        if (Minecraft.getInstance().options.narrator().get() != NarratorStatus.OFF) {
-            MainClass.getScreenReader().say(text, MainClass.interrupt);
-            MainClass.interrupt = true; // The default value
-        }
-        callbackInfo.cancel();
-    }
-
-    @Inject(at = @At("HEAD"), method = "sayChat", cancellable = true)
-    private void sayChat(Component text, CallbackInfo callbackInfo) {
-        if (Minecraft.getInstance().options.narrator().get().shouldNarrateChat()) {
-            String string = text.getString();
-            MainClass.getScreenReader().say(string, false);
-        }
-        callbackInfo.cancel();
-    }
-
-    @Inject(at = @At("HEAD"), method = "say", cancellable = true)
-    private void say(Component text, CallbackInfo callbackInfo) {
-        String string = text.getString();
-        if (Minecraft.getInstance().options.narrator().get().shouldNarrateSystem() && !string.isEmpty()) {
-            MainClass.getScreenReader().say(string, true);
-        }
-        callbackInfo.cancel();
-    }
-
-    @Inject(at = @At("HEAD"), method = "updateNarratorStatus", cancellable = true)
-    private void updateNarratorStatus(NarratorStatus mode, CallbackInfo callbackInfo) {
-        ToastManager toastManager = Minecraft.getInstance().getToastManager();
-        if (MainClass.getScreenReader() != null && MainClass.getScreenReader().isInitialized()) {
-            MainClass.getScreenReader().say(Component.translatable("options.narrator").append(" : ").append(mode.getName()).getString(), true);
-            if (mode == NarratorStatus.OFF) {
-                SystemToast.addOrUpdate(toastManager, SystemToast.SystemToastId.NARRATOR_TOGGLE, Component.translatable("narrator.toast.disabled"), null);
-            } else {
-                SystemToast.addOrUpdate(toastManager, SystemToast.SystemToastId.NARRATOR_TOGGLE, Component.translatable("narrator.toast.enabled"), mode.getName());
-            }
-        } else {
-            SystemToast.addOrUpdate(toastManager, SystemToast.SystemToastId.NARRATOR_TOGGLE, Component.translatable("narrator.toast.disabled"), Component.translatable("options.narrator.notavailable"));
-        }
+        MainClass.getScreenReader().say(text, interrupt);
         callbackInfo.cancel();
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorMixin.java
@@ -3,7 +3,6 @@ package org.mcaccess.minecraftaccess.mixin;
 import com.mojang.text2speech.Narrator;
 import net.minecraft.client.GameNarrator;
 import net.minecraft.client.Minecraft;
-import net.minecraft.network.chat.Component;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.utils.NarratorDummy;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,7 +10,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(GameNarrator.class)
 public class GameNarratorMixin {

--- a/common/src/main/resources/minecraft_access.mixins.json
+++ b/common/src/main/resources/minecraft_access.mixins.json
@@ -27,6 +27,7 @@
     "EyeOfEnderMixin",
     "GameModeIconAccessor",
     "GameModeSwitcherScreenMixin",
+    "GameNarratorAccessor",
     "GameNarratorMixin",
     "GuiAccessor",
     "GuiGraphicsMixin",


### PR DESCRIPTION
This simplifies the code and makes Jade's narration work again.
# Changelog

## Bug Fixes

- Third-party mods like Jade that use narrateMessage will now speak with Minecraft Access instead of the vanilla narrator voice