### PR TITLE
Updated POI config defaults to be object tracker ready

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/Config.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/Config.java
@@ -133,7 +133,7 @@ public class Config implements ConfigData {
     public static final class POI {
         private POI() {}
 
-        public boolean speakDistance = false;
+        public boolean speakDistance = true;
         @ConfigEntry.Gui.CollapsibleObject
         public Blocks blocks = new Blocks();
         @ConfigEntry.Gui.CollapsibleObject
@@ -148,7 +148,7 @@ public class Config implements ConfigData {
 
             public boolean enabled = true;
             public boolean detectFluidBlocks = true;
-            public int range = 6;
+            public int range = 24;
             public boolean playSound = true;
             public float volume = 0.25f;
             public boolean playSoundForOtherBlocks = true;
@@ -159,7 +159,7 @@ public class Config implements ConfigData {
             private Entities() {}
 
             public boolean enabled = true;
-            public int range = 6;
+            public int range = 24;
             public boolean playSound = true;
             public float volume = 0.25f;
             public int delay = 3000;


### PR DESCRIPTION

# Changelog

## Feature Updates
- The blocks and entities POI range is now 24 blocks by default to better leverage the new object tracker
- Speak relative distance is now on by default to give the player more awareness when dealing with POIs in the object tracker