### PR TITLE
Refactor key mappings

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/MainClass.java
@@ -58,6 +58,7 @@ public final class MainClass {
     public static PlayerStatus playerStatus = null;
     public static PlayerWarnings playerWarnings = null;
     public static POIManager poiManager = null;
+    public static PositionNarrator positionNarrator = null;
     public static XPIndicator xpIndicator = null;
 
     private MainClass() {
@@ -128,7 +129,7 @@ public final class MainClass {
 
         facingDirection.tick();
 
-        PositionNarrator.getINSTANCE().tick();
+        positionNarrator.tick();
 
         if (WorldUtils.getClientPlayer() != null) {
             if (playerStatus != null) {
@@ -180,6 +181,7 @@ public final class MainClass {
         playerStatus = new PlayerStatus();
         playerWarnings = new PlayerWarnings();
         poiManager = new POIManager();
+        positionNarrator = new PositionNarrator();
         xpIndicator = new XPIndicator();
 
         Minecraft client = Minecraft.getInstance();

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/FacingDirection.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/FacingDirection.java
@@ -2,12 +2,12 @@ package org.mcaccess.minecraftaccess.features;
 
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
 
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.utils.KeyBindingsHandler;
 import org.mcaccess.minecraftaccess.utils.position.PlayerPositionUtils;
-import org.mcaccess.minecraftaccess.utils.system.KeyUtils;
 
 /**
  * Adds key binding to narrate the player's facing direction.<br>
@@ -15,25 +15,29 @@ import org.mcaccess.minecraftaccess.utils.system.KeyUtils;
  */
 @Slf4j
 public class FacingDirection {
+    private boolean isDirectionNarrationKeyDown = false;
+
     public void tick() {
-        Minecraft minecraftClient = Minecraft.getInstance();
-        if (minecraftClient.player == null) return;
-        if (minecraftClient.screen != null) return;
+        Minecraft client = Minecraft.getInstance();
+        if (client.player == null) return;
+        if (client.screen != null) return;
 
-        boolean isDirectionNarrationKeyPressed = KeyUtils.isAnyPressed(KeyBindingsHandler.DIRECTION_NARRATION_KEY.mapping);
-        if (!isDirectionNarrationKeyPressed) return;
+        if (KeyBindingsHandler.DIRECTION_NARRATION_KEY.mapping.consumeClick()) {
+            if (!isDirectionNarrationKeyDown) {
+                isDirectionNarrationKeyDown = true;
+                String narration;
+                if (Screen.hasAltDown()) {
+                    String verticleDirection = PlayerPositionUtils.getVerticalFacingDirectionInWords();
+                    narration = I18n.get("minecraft_access.other.facing_direction", verticleDirection);
+                } else {
+                    String horizontalDirection = PlayerPositionUtils.getHorizontalFacingDirectionInWords();
+                    narration = I18n.get("minecraft_access.other.facing_direction", horizontalDirection);
+                }
 
-        boolean isLeftAltPressed = KeyUtils.isLeftAltPressed();
-
-        String narration;
-        if (isLeftAltPressed) {
-            String t = PlayerPositionUtils.getVerticalFacingDirectionInWords();
-            narration = I18n.get("minecraft_access.other.facing_direction", t);
-        } else {
-            String string = PlayerPositionUtils.getHorizontalFacingDirectionInWords();
-            narration = I18n.get("minecraft_access.other.facing_direction", string);
+                MainClass.narrate(narration, true);
+            }
+        } else if (!KeyBindingsHandler.DIRECTION_NARRATION_KEY.mapping.isDown()) {
+            isDirectionNarrationKeyDown = false;
         }
-
-        MainClass.narrate(narration, true);
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/MenuFix.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/MenuFix.java
@@ -26,8 +26,6 @@ import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
 import net.minecraft.client.gui.screens.worldselection.EditWorldScreen;
 import net.minecraft.client.gui.screens.worldselection.SelectWorldScreen;
 
-import org.mcaccess.minecraftaccess.Config;
-import org.mcaccess.minecraftaccess.utils.system.KeyUtils;
 import org.mcaccess.minecraftaccess.utils.system.MouseUtils;
 
 /**
@@ -37,6 +35,9 @@ import org.mcaccess.minecraftaccess.utils.system.MouseUtils;
  */
 @Slf4j
 public final class MenuFix {
+    private static boolean isRKeyDown = false;
+    private static boolean wasAltDownLastTick = false;
+
     private static Class<? extends Screen> prevScreenClass = TitleScreen.class;
     private static final Set<Class<? extends Screen>> MENUS_NEED_FIX = Set.of(
             TitleScreen.class,
@@ -63,24 +64,34 @@ public final class MenuFix {
     private MenuFix() {
     }
 
-    public static void tick(Minecraft minecraftClient) {
-        if (!Config.getInstance().menuFixEnabled || minecraftClient.screen == null) {
+    public static void tick(Minecraft client) {
+        if (client.screen == null) {
             return;
         }
 
-        Class<? extends Screen> currentScreen = minecraftClient.screen.getClass();
+        Class<? extends Screen> currentScreen = client.screen.getClass();
         if (MENUS_NEED_FIX.contains(currentScreen)) {
             if (prevScreenClass != currentScreen) {
-                log.debug("Performing menu fix on {}", minecraftClient.screen.getTitle().getString());
+                log.debug("Performing menu fix on {}", client.screen.getTitle().getString());
                 moveMouseCursor();
                 prevScreenClass = currentScreen;
             }
 
-            boolean isLeftAltPressed = KeyUtils.isLeftAltPressed();
-            boolean isRPressed = KeyUtils.isAnyPressed(InputConstants.KEY_R);
-            if (isLeftAltPressed && isRPressed) {
-                moveMouseCursor();
+            boolean isAltDown = Screen.hasAltDown();
+            long window = client.getWindow().getWindow();
+            if (isAltDown) {
+                if (InputConstants.isKeyDown(window, InputConstants.KEY_R)) {
+                    if (!isRKeyDown && wasAltDownLastTick) {
+                        isRKeyDown = true;
+                        moveMouseCursor();
+                    } else if (!isRKeyDown) {
+                        isRKeyDown = true;
+                    }
+                } else {
+                    isRKeyDown = false;
+                }
             }
+            wasAltDownLastTick = isAltDown;
         }
     }
 

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/MouseKeySimulation.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/MouseKeySimulation.java
@@ -1,64 +1,96 @@
 package org.mcaccess.minecraftaccess.features;
 
-import java.util.Set;
-
-import net.minecraft.util.Tuple;
-import org.apache.commons.lang3.tuple.Triple;
-
 import org.mcaccess.minecraftaccess.Config;
 import org.mcaccess.minecraftaccess.utils.KeyBindingsHandler;
-import org.mcaccess.minecraftaccess.utils.condition.Interval;
-import org.mcaccess.minecraftaccess.utils.condition.IntervalKeystroke;
-import org.mcaccess.minecraftaccess.utils.condition.Keystroke;
-import org.mcaccess.minecraftaccess.utils.system.KeyUtils;
 import org.mcaccess.minecraftaccess.utils.system.MouseUtils;
 
 /**
  * Simulate mouse key operations by programmatically invoking vanilla mouse key operation handlers.
+ * Supports both press-and-hold and click functionality for mouse buttons.
  */
-public final class MouseKeySimulation {
-    private static final Keystroke[] MOUSE_CLICKS = new Keystroke[]{
-            new Keystroke(() -> KeyUtils.isAnyPressed(KeyBindingsHandler.MOUSE_SIMULATION_LEFT_MOUSE_KEY.mapping)),
-            new Keystroke(() -> KeyUtils.isAnyPressed(KeyBindingsHandler.MOUSE_SIMULATION_MIDDLE_MOUSE_KEY.mapping)),
-            new Keystroke(() -> KeyUtils.isAnyPressed(KeyBindingsHandler.MOUSE_SIMULATION_RIGHT_MOUSE_KEY.mapping)),
-    };
-    public static final Set<Triple<Keystroke, Runnable, Runnable>> MOUSE_CLICK_ACTIONS = Set.of(
-            Triple.of(MOUSE_CLICKS[0], MouseUtils.Key.LEFT::press, MouseUtils.Key.LEFT::release),
-            Triple.of(MOUSE_CLICKS[1], MouseUtils.Key.MIDDLE::press, MouseUtils.Key.MIDDLE::release),
-            Triple.of(MOUSE_CLICKS[2], MouseUtils.Key.RIGHT::press, MouseUtils.Key.RIGHT::release)
-    );
-    private static final IntervalKeystroke[] MOUSE_SCROLLS = new IntervalKeystroke[]{
-            new IntervalKeystroke(KeyBindingsHandler.MOUSE_SIMULATION_SCROLL_UP_KEY.mapping),
-            new IntervalKeystroke(KeyBindingsHandler.MOUSE_SIMULATION_SCROLL_DOWN_KEY.mapping),
-    };
-    public static final Set<Tuple<IntervalKeystroke, Runnable>> MOUSE_SCROLL_ACTIONS = Set.of(
-            new Tuple<IntervalKeystroke, Runnable>(MOUSE_SCROLLS[0], MouseUtils.Wheel.UP::scroll),
-            new Tuple<IntervalKeystroke, Runnable>(MOUSE_SCROLLS[1], MouseUtils.Wheel.DOWN::scroll)
-    );
+public class MouseKeySimulation {
+    private static int scrollDelayMilliseconds;
+    private static long lastScrollUpTime = 0;
+    private static long lastScrollDownTime = 0;
 
-    private MouseKeySimulation() {
-    }
+    private static boolean leftMouseKeyWasDown = false;
+    private static boolean middleMouseKeyWasDown = false;
+    private static boolean rightMouseKeyWasDown = false;
 
-    private static void loadConfig() {
-        Config.MouseSimulation config = Config.getInstance().mouseSimulation;
-        MOUSE_SCROLLS[0].interval.setDelay(config.scrollDelayMilliseconds, Interval.Unit.MILLISECOND);
-        MOUSE_SCROLLS[1].interval.setDelay(config.scrollDelayMilliseconds, Interval.Unit.MILLISECOND);
-    }
+    private static boolean scrollUpKeyWasDown = false;
+    private static boolean scrollDownKeyWasDown = false;
 
     public static void tick() {
         loadConfig();
-        MOUSE_SCROLL_ACTIONS.forEach(t -> {
-            if (t.getA().canBeTriggered()) {
-                t.getB().run();
-            }
-        });
+        checkMouseButtonKeys();
+        checkScrollKeys();
+    }
 
-        MOUSE_CLICK_ACTIONS.forEach(t -> {
-            if (t.getLeft().isPressed()) {
-                t.getMiddle().run();
-            } else if (t.getLeft().isReleased()) {
-                t.getRight().run();
+    /**
+     * Load configuration settings
+     */
+    private static void loadConfig() {
+        scrollDelayMilliseconds = Config.getInstance().mouseSimulation.scrollDelayMilliseconds;
+    }
+
+    /**
+     * Check all mouse button keys (left, middle, right) and handle press/hold/release
+     */
+    private static void checkMouseButtonKeys() {
+        boolean leftMouseKeyIsDown = KeyBindingsHandler.MOUSE_SIMULATION_LEFT_MOUSE_KEY.mapping.isDown();
+        if (leftMouseKeyIsDown && !leftMouseKeyWasDown) {
+            MouseUtils.Key.LEFT.press();
+        } else if (!leftMouseKeyIsDown && leftMouseKeyWasDown) {
+            MouseUtils.Key.LEFT.release();
+        }
+        leftMouseKeyWasDown = leftMouseKeyIsDown;
+
+        boolean middleMouseKeyIsDown = KeyBindingsHandler.MOUSE_SIMULATION_MIDDLE_MOUSE_KEY.mapping.isDown();
+        if (middleMouseKeyIsDown && !middleMouseKeyWasDown) {
+            MouseUtils.Key.MIDDLE.press();
+        } else if (!middleMouseKeyIsDown && middleMouseKeyWasDown) {
+            MouseUtils.Key.MIDDLE.release();
+        }
+        middleMouseKeyWasDown = middleMouseKeyIsDown;
+
+        boolean rightMouseKeyIsDown = KeyBindingsHandler.MOUSE_SIMULATION_RIGHT_MOUSE_KEY.mapping.isDown();
+        if (rightMouseKeyIsDown && !rightMouseKeyWasDown) {
+            MouseUtils.Key.RIGHT.press();
+        } else if (!rightMouseKeyIsDown && rightMouseKeyWasDown) {
+            MouseUtils.Key.RIGHT.release();
+        }
+        rightMouseKeyWasDown = rightMouseKeyIsDown;
+    }
+
+    /**
+     * Check scroll keys with delay handling
+     */
+    private static void checkScrollKeys() {
+        long currentTime = System.currentTimeMillis();
+
+        boolean scrollUpKeyIsDown = KeyBindingsHandler.MOUSE_SIMULATION_SCROLL_UP_KEY.mapping.isDown();
+        if (scrollUpKeyIsDown) {
+            if (!scrollUpKeyWasDown || canScroll(lastScrollUpTime)) {
+                MouseUtils.Wheel.UP.scroll();
+                lastScrollUpTime = currentTime;
             }
-        });
+        }
+        scrollUpKeyWasDown = scrollUpKeyIsDown;
+
+        boolean scrollDownKeyIsDown = KeyBindingsHandler.MOUSE_SIMULATION_SCROLL_DOWN_KEY.mapping.isDown();
+        if (scrollDownKeyIsDown) {
+            if (!scrollDownKeyWasDown || canScroll(lastScrollDownTime)) {
+                MouseUtils.Wheel.DOWN.scroll();
+                lastScrollDownTime = currentTime;
+            }
+        }
+        scrollDownKeyWasDown = scrollDownKeyIsDown;
+    }
+
+    /**
+     * Check if enough time has passed for scrolling
+     */
+    private static boolean canScroll(long lastScrollTime) {
+        return System.currentTimeMillis() - lastScrollTime >= scrollDelayMilliseconds;
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
@@ -17,13 +17,19 @@ public class NarrateHeldItem {
     private String previousItemName = "";
     private int previousItemCount = 0;
     private int previousSelectedSlot = 0;
+    private boolean isNarrateHeldItemKeyDown = false;
 
     public void tick() {
         LocalPlayer player = Minecraft.getInstance().player;
         if (player == null) return;
 
-        while (KeyBindingsHandler.NARRATE_HELD_ITEM_KEY.mapping.consumeClick()) {
-            narrateHand(Screen.hasAltDown());
+        if (KeyBindingsHandler.NARRATE_HELD_ITEM_KEY.mapping.consumeClick()) {
+            if (!isNarrateHeldItemKeyDown) {
+                isNarrateHeldItemKeyDown = true;
+                narrateHand(Screen.hasAltDown());
+            }
+        } else if (!KeyBindingsHandler.NARRATE_HELD_ITEM_KEY.mapping.isDown()) {
+            isNarrateHeldItemKeyDown = false;
         }
 
         ItemStack currentItemStack = player.getMainHandItem();
@@ -80,6 +86,6 @@ public class NarrateHeldItem {
         int heldItemCount = heldItem.getCount();
         heldItemName = (heldItemCount != 1 && !heldItem.isEmpty()) ? heldItemCount + " " + heldItemName : heldItemName;
 
-        MainClass.narrate("%s: %s".formatted(hand, heldItemName), false);
+        MainClass.narrate("%s: %s".formatted(hand, heldItemName), true);
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/PlayerStatus.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/PlayerStatus.java
@@ -1,7 +1,5 @@
 package org.mcaccess.minecraftaccess.features;
 
-import java.util.Objects;
-
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
@@ -11,10 +9,6 @@ import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.utils.KeyBindingsHandler;
 import org.mcaccess.minecraftaccess.utils.NarrationUtils;
 import org.mcaccess.minecraftaccess.utils.PlayerUtils;
-import org.mcaccess.minecraftaccess.utils.condition.Interval;
-import org.mcaccess.minecraftaccess.utils.condition.IntervalKeystroke;
-import org.mcaccess.minecraftaccess.utils.condition.Keystroke;
-import org.mcaccess.minecraftaccess.utils.system.KeyUtils;
 
 /**
  * Adds a key bind to narrate the player's non potion related statuses.<br>
@@ -22,80 +16,82 @@ import org.mcaccess.minecraftaccess.utils.system.KeyUtils;
  */
 @Slf4j
 public class PlayerStatus {
-    IntervalKeystroke narrationKey = new IntervalKeystroke(
-            () -> KeyUtils.isAnyPressed(KeyBindingsHandler.NARRATE_PLAYER_STATUS_KEY.mapping),
-            Keystroke.TriggeredAt.PRESSED,
-            // 3s interval
-            Interval.ms(3000));
+    private boolean isStatusKeyDown = false;
 
     public void tick() {
-        Minecraft minecraftClient = Minecraft.getInstance();
-        if (minecraftClient.player == null) return;
-        if (minecraftClient.screen != null) return;
+        Minecraft client = Minecraft.getInstance();
+        if (client.player == null) return;
+        if (client.screen != null) return;
 
-        if (narrationKey.canBeTriggered()) {
-            if (Screen.hasControlDown()) {
-                PlayerUtils.narrateCurrentPlayerEffects();
-                return;
-            }
+        if (KeyBindingsHandler.NARRATE_PLAYER_STATUS_KEY.mapping.consumeClick()) {
+            if (!isStatusKeyDown) {
+                isStatusKeyDown = true;
+                if (Screen.hasControlDown()) {
+                    PlayerUtils.narrateCurrentPlayerEffects();
+                    return;
+                }
 
-            double health = Math.round((minecraftClient.player.getHealth() / 2.0) * 10.0) / 10.0;
-            double maxHealth = Math.round((minecraftClient.player.getMaxHealth() / 2.0) * 10.0) / 10.0;
-            double absorption = Math.round((minecraftClient.player.getAbsorptionAmount() / 2.0) * 10.0) / 10.0;
-            double hunger = Math.round((minecraftClient.player.getFoodData().getFoodLevel() / 2.0) * 10.0) / 10.0;
-            double maxHunger = Math.round((20 / 2.0) * 10.0) / 10.0;
-            double armor = Math.round((minecraftClient.player.getArmorValue() / 2.0) * 10.0) / 10.0;
-            double air = Math.round((minecraftClient.player.getAirSupply() / 20.0) * 10.0) / 10.0;
-            double maxAir = Math.round((minecraftClient.player.getMaxAirSupply() / 20.0) * 10.0) / 10.0;
-            double frostExposurePercent = Math.round((minecraftClient.player.getPercentFrozen() * 100.0) * 10.0) / 10.0;
+                double health = Math.round((client.player.getHealth() / 2.0) * 10.0) / 10.0;
+                double maxHealth = Math.round((client.player.getMaxHealth() / 2.0) * 10.0) / 10.0;
+                double absorption = Math.round((client.player.getAbsorptionAmount() / 2.0) * 10.0) / 10.0;
+                double hunger = Math.round((client.player.getFoodData().getFoodLevel() / 2.0) * 10.0) / 10.0;
+                double maxHunger = Math.round((20 / 2.0) * 10.0) / 10.0;
+                double armor = Math.round((client.player.getArmorValue() / 2.0) * 10.0) / 10.0;
+                double air = Math.round((client.player.getAirSupply() / 20.0) * 10.0) / 10.0;
+                double maxAir = Math.round((client.player.getMaxAirSupply() / 20.0) * 10.0) / 10.0;
+                double frostExposurePercent = Math.round((client.player.getPercentFrozen() * 100.0) * 10.0) / 10.0;
 
-            StringBuilder narration = new StringBuilder();
+                StringBuilder narration = new StringBuilder();
 
-            if (PlayerUtils.isSurvival() || PlayerUtils.isAdventure()) {
-                if (!Screen.hasAltDown()) {
-                    if (absorption > 0) {
-                        narration.append(I18n.get(
-                                "minecraft_access.player_status.base_with_absorption",
-                                NarrationUtils.narrateNumber(health),
-                                NarrationUtils.narrateNumber(absorption),
-                                NarrationUtils.narrateNumber(maxHealth),
-                                NarrationUtils.narrateNumber(hunger),
-                                NarrationUtils.narrateNumber(maxHunger),
-                                NarrationUtils.narrateNumber(armor))
-                        );
-                    } else {
-                        narration.append(I18n.get(
-                                "minecraft_access.player_status.base",
-                                NarrationUtils.narrateNumber(health),
-                                NarrationUtils.narrateNumber(maxHealth),
-                                NarrationUtils.narrateNumber(hunger),
-                                NarrationUtils.narrateNumber(maxHunger),
-                                NarrationUtils.narrateNumber(armor))
-                        );
+                if (PlayerUtils.isSurvival() || PlayerUtils.isAdventure()) {
+                    if (!Screen.hasAltDown()) {
+                        if (absorption > 0) {
+                            narration.append(I18n.get(
+                                    "minecraft_access.player_status.base_with_absorption",
+                                    NarrationUtils.narrateNumber(health),
+                                    NarrationUtils.narrateNumber(absorption),
+                                    NarrationUtils.narrateNumber(maxHealth),
+                                    NarrationUtils.narrateNumber(hunger),
+                                    NarrationUtils.narrateNumber(maxHunger),
+                                    NarrationUtils.narrateNumber(armor))
+                            );
+                        } else {
+                            narration.append(I18n.get(
+                                    "minecraft_access.player_status.base",
+                                    NarrationUtils.narrateNumber(health),
+                                    NarrationUtils.narrateNumber(maxHealth),
+                                    NarrationUtils.narrateNumber(hunger),
+                                    NarrationUtils.narrateNumber(maxHunger),
+                                    NarrationUtils.narrateNumber(armor))
+                            );
+                        }
+                    }
+
+                    if ((client.player.isUnderWater() || client.player.getAirSupply() < client.player.getMaxAirSupply()) && !client.player.canBreatheUnderwater()) {
+                        air = Math.max(air, 0.0);
+                        narration.append(I18n.get("minecraft_access.player_status.air",
+                                NarrationUtils.narrateNumber(air),
+                                NarrationUtils.narrateNumber(maxAir)));
+                    }
+
+                    if ((client.player.isInPowderSnow || frostExposurePercent > 0) && client.player.canFreeze()) {
+                        narration.append(I18n.get("minecraft_access.player_status.frost", NarrationUtils.narrateNumber(frostExposurePercent)));
                     }
                 }
 
-                if ((minecraftClient.player.isUnderWater() || minecraftClient.player.getAirSupply() < minecraftClient.player.getMaxAirSupply()) && !minecraftClient.player.canBreatheUnderwater()) {
-                    air = Math.max(air, 0.0);
-                    narration.append(I18n.get("minecraft_access.player_status.air", NarrationUtils.narrateNumber(air), NarrationUtils.narrateNumber(maxAir)));
+                if (narration.isEmpty() && (PlayerUtils.isSurvival() || PlayerUtils.isAdventure())) {
+                    narration.append(I18n.get("minecraft_access.player_status.no_conditional_status"));
                 }
 
-                if ((minecraftClient.player.isInPowderSnow || frostExposurePercent > 0) && minecraftClient.player.canFreeze()) {
-                    narration.append(I18n.get("minecraft_access.player_status.frost", NarrationUtils.narrateNumber(frostExposurePercent)));
+                if (!narration.toString().equals(I18n.get("minecraft_access.player_status.no_conditional_status"))) {
+                    addGameMode(narration);
                 }
-            }
 
-            if (narration.isEmpty() && (PlayerUtils.isSurvival() || PlayerUtils.isAdventure())) {
-                narration.append(I18n.get("minecraft_access.player_status.no_conditional_status"));
+                MainClass.narrate(narration.toString(), true);
             }
-
-            if (!Objects.equals(narration.toString(), I18n.get("minecraft_access.player_status.no_conditional_status"))) {
-                addGameMode(narration);
-            }
-
-            MainClass.narrate(narration.toString(), true);
+        } else if (!KeyBindingsHandler.NARRATE_PLAYER_STATUS_KEY.mapping.isDown()) {
+            isStatusKeyDown = false;
         }
-        narrationKey.updateStateForNextTick();
     }
 
     public void addGameMode(StringBuilder narration) {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/PositionNarrator.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/PositionNarrator.java
@@ -1,54 +1,80 @@
 package org.mcaccess.minecraftaccess.features;
 
 import com.mojang.blaze3d.platform.InputConstants;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.utils.KeyBindingsHandler;
-import org.mcaccess.minecraftaccess.utils.condition.Keystroke;
 import org.mcaccess.minecraftaccess.utils.position.PlayerPositionUtils;
-import org.mcaccess.minecraftaccess.utils.system.KeyUtils;
 
-/**
- * Adds key bindings to narrate the player's position.<br><br>
- * Keybindings and combinations:<br>
- * 1. Narrate Player Position Key (default: G) = Narrates the player's x y and z position.<br>
- * 2. Left Alt + X = Narrates only the x position.<br>
- * 3. Left Alt + C = Narrates only the y position.<br>
- * 4. Left Alt + Z = Narrates only the z position.<br>
- */
 @Slf4j
 public final class PositionNarrator {
-    @Getter
-    private static final PositionNarrator INSTANCE = new PositionNarrator();
-    public static Keystroke keyX = new Keystroke(() -> KeyUtils.isAnyPressed(InputConstants.KEY_X));
-    public static Keystroke keyC = new Keystroke(() -> KeyUtils.isAnyPressed(InputConstants.KEY_C));
-    public static Keystroke keyZ = new Keystroke(() -> KeyUtils.isAnyPressed(InputConstants.KEY_Z));
-    public static Keystroke positionNarrationKey = new Keystroke(() -> KeyUtils.isAnyPressed(KeyBindingsHandler.POSITION_NARRATION_KEY.mapping));
-
-    private PositionNarrator() {
-    }
+    private boolean isXKeyDown = false;
+    private boolean isCKeyDown = false;
+    private boolean isZKeyDown = false;
+    private boolean isPositionNarrationKeyDown = false;
+    private boolean wasAltDownLastTick = false;
 
     public void tick() {
-        Minecraft minecraftClient = Minecraft.getInstance();
-        if (minecraftClient.player == null) return;
-        if (minecraftClient.screen != null) return;
+        Minecraft client = Minecraft.getInstance();
+        if (client.player == null || client.screen != null) return;
 
-        boolean isLeftAltPressed = KeyUtils.isLeftAltPressed();
-        if (isLeftAltPressed) {
-            if (keyX.canBeTriggered()) {
-                MainClass.narrate(PlayerPositionUtils.getNarratableXPos(), true);
-            } else if (keyC.canBeTriggered()) {
-                MainClass.narrate(PlayerPositionUtils.getNarratableYPos(), true);
-            } else if (keyZ.canBeTriggered()) {
-                MainClass.narrate(PlayerPositionUtils.getNarratableZPos(), true);
+        boolean isAltDown = Screen.hasAltDown();
+        long window = client.getWindow().getWindow();
+
+        if (isAltDown) {
+            if (InputConstants.isKeyDown(window, InputConstants.KEY_X)) {
+                // Only trigger if Alt was already down when X was pressed
+                if (!isXKeyDown && wasAltDownLastTick) {
+                    isXKeyDown = true;
+                    MainClass.narrate(PlayerPositionUtils.getNarratableXPos(), true);
+                } else if (!isXKeyDown) {
+                    // X pressed but Alt wasn't down first - just mark as down without narrating
+                    isXKeyDown = true;
+                }
+            } else {
+                isXKeyDown = false;
             }
+
+            if (InputConstants.isKeyDown(window, InputConstants.KEY_C)) {
+                if (!isCKeyDown && wasAltDownLastTick) {
+                    isCKeyDown = true;
+                    MainClass.narrate(PlayerPositionUtils.getNarratableYPos(), true);
+                } else if (!isCKeyDown) {
+                    isCKeyDown = true;
+                }
+            } else {
+                isCKeyDown = false;
+            }
+
+            if (InputConstants.isKeyDown(window, InputConstants.KEY_Z)) {
+                if (!isZKeyDown && wasAltDownLastTick) {
+                    isZKeyDown = true;
+                    MainClass.narrate(PlayerPositionUtils.getNarratableZPos(), true);
+                } else if (!isZKeyDown) {
+                    isZKeyDown = true;
+                }
+            } else {
+                isZKeyDown = false;
+            }
+        } else {
+            isXKeyDown = false;
+            isCKeyDown = false;
+            isZKeyDown = false;
         }
 
-        if (positionNarrationKey.canBeTriggered()) {
-            MainClass.narrate(PlayerPositionUtils.getNarratableXYZPosition(), true);
+        // Update Alt state for next tick
+        wasAltDownLastTick = isAltDown;
+
+        if (KeyBindingsHandler.POSITION_NARRATION_KEY.mapping.consumeClick()) {
+            if (!isPositionNarrationKeyDown) {
+                isPositionNarrationKeyDown = true;
+                MainClass.narrate(PlayerPositionUtils.getNarratableXYZPosition(), true);
+            }
+        } else if (!KeyBindingsHandler.POSITION_NARRATION_KEY.mapping.isDown()) {
+            isPositionNarrationKeyDown = false;
         }
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/LockingHandler.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/LockingHandler.java
@@ -34,7 +34,6 @@ import org.mcaccess.minecraftaccess.utils.PlayerUtils;
 import org.mcaccess.minecraftaccess.utils.WorldUtils;
 import org.mcaccess.minecraftaccess.utils.condition.Interval;
 import org.mcaccess.minecraftaccess.utils.position.PlayerPositionUtils;
-import org.mcaccess.minecraftaccess.utils.system.KeyUtils;
 
 /**
  * Locks on to the nearest entity or block.<br><br>
@@ -50,6 +49,8 @@ public class LockingHandler {
     private boolean isLockedOnWhereEyeOfEnderDisappears = false;
     private Map<Property<?>, Comparable<?>> entriesOfLockedOnBlock;
     private final Interval interval = Interval.defaultDelay();
+    private boolean isLockingHandlerKeyDown = false;
+    private boolean wasAltDownLastTick = false;
     private boolean aimAssistActive = false;
     // 0 = can't shoot, 1 = can shoot
     private int lastAimAssistCue = -1;
@@ -68,32 +69,39 @@ public class LockingHandler {
     }
 
     public void tick() {
-        Minecraft minecraftClient = Minecraft.getInstance();
+        Minecraft client = Minecraft.getInstance();
 
         loadConfig();
-        if (!interval.isReady()) return;
-        if (minecraftClient.player == null) return;
-        if (minecraftClient.level == null) return;
-        if (minecraftClient.screen != null) return;
+        if (client.player == null) return;
+        if (client.level == null) return;
+        if (client.screen != null) return;
 
         handleLockingKeyPressing();
-        lookAtLockedTarget();
-        bowAimingAssist();
+
+        if (interval.isReady()) {
+            lookAtLockedTarget();
+            bowAimingAssist();
+        }
     }
 
     private void handleLockingKeyPressing() {
-        boolean isLockingKeyPressed = KeyUtils.isAnyPressed(KeyBindingsHandler.LOCKING_HANDLER_KEY.mapping);
-        if (isLockingKeyPressed && Screen.hasAltDown()) {
-            if (lockedOnEntity != null || lockedOnBlockPos != null) {
-                unlock(true, true);
-                interval.beReady();
+        boolean isAltDown = Screen.hasAltDown();
+        if (KeyBindingsHandler.LOCKING_HANDLER_KEY.mapping.consumeClick()) {
+            if (!isLockingHandlerKeyDown) {
+                isLockingHandlerKeyDown = true;
+                if (wasAltDownLastTick && isAltDown) {
+                    if (lockedOnEntity != null || lockedOnBlockPos != null) {
+                        unlock(true, true);
+                    }
+                } else {
+                    relock();
+                }
             }
-        } else if (isLockingKeyPressed) {
-            relock();
-            interval.reset();
-        } else {
-            interval.beReady();
+        } else if (!KeyBindingsHandler.LOCKING_HANDLER_KEY.mapping.isDown()) {
+            isLockingHandlerKeyDown = false;
         }
+
+        wasAltDownLastTick = isAltDown;
     }
 
     private void lookAtLockedTarget() {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/ObjectTracker.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/ObjectTracker.java
@@ -21,18 +21,17 @@ import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.utils.KeyBindingsHandler;
 import org.mcaccess.minecraftaccess.utils.NarrationUtils;
 import org.mcaccess.minecraftaccess.utils.WorldUtils;
-import org.mcaccess.minecraftaccess.utils.condition.Keystroke;
-import org.mcaccess.minecraftaccess.utils.system.KeyUtils;
 
 @Slf4j
 public class ObjectTracker {
     public static final String START_OF_LIST = "minecraft_access.other.start_of_list";
     public static final String END_OF_LIST = "minecraft_access.other.end_of_list";
 
-    private final Keystroke nextItemKeyPressed = new Keystroke(() -> KeyUtils.isAnyPressed(KeyBindingsHandler.OBJECT_TRACKER_NEXT_ITEM.mapping), Keystroke.TriggeredAt.PRESSED);
-    private final Keystroke previousItemKeyPressed = new Keystroke(() -> KeyUtils.isAnyPressed(KeyBindingsHandler.OBJECT_TRACKER_PREVIOUS_ITEM.mapping), Keystroke.TriggeredAt.PRESSED);
-    private final Keystroke narrateCurrentObjectKeyPressed = new Keystroke(() -> KeyUtils.isAnyPressed(KeyBindingsHandler.OBJECT_TRACKER_NARRATE_CURRENT_OBJECT.mapping), Keystroke.TriggeredAt.PRESSED);
-    private final Keystroke targetNearestObjectKeyPressed = new Keystroke(() -> KeyUtils.isAnyPressed(KeyBindingsHandler.TARGET_NEAREST_OBJECT.mapping), Keystroke.TriggeredAt.PRESSED);
+    private boolean isNextItemKeyDown = false;
+    private boolean isPreviousItemKeyDown = false;
+    private boolean isNarrateCurrentObjectKeyDown = false;
+    private boolean isTargetNearestObjectKeyDown = false;
+    private boolean wasControlDownLastTick = false;
 
     @Getter
     private Object currentObject = null;
@@ -60,23 +59,60 @@ public class ObjectTracker {
     }
 
     public void tick() {
-        Minecraft minecraftClient = Minecraft.getInstance();
+        Minecraft client = Minecraft.getInstance();
 
-        if (minecraftClient.player == null) return;
-        if (minecraftClient.level == null) return;
-        if (minecraftClient.screen != null) return;
+        if (client.player == null) return;
+        if (client.level == null) return;
+        if (client.screen != null) return;
 
         updateGroups();
 
-        if (narrateCurrentObjectKeyPressed.canBeTriggered()) narrateCurrentObject(true);
+        boolean isControlDown = Screen.hasControlDown() && wasControlDownLastTick;
+        if (KeyBindingsHandler.OBJECT_TRACKER_NARRATE_CURRENT_OBJECT.mapping.consumeClick()) {
+            if (!isNarrateCurrentObjectKeyDown) {
+                isNarrateCurrentObjectKeyDown = true;
+                narrateCurrentObject(true);
+            }
+        } else if (!KeyBindingsHandler.OBJECT_TRACKER_NARRATE_CURRENT_OBJECT.mapping.isDown()) {
+            isNarrateCurrentObjectKeyDown = false;
+        }
 
-        if (nextItemKeyPressed.canBeTriggered() && Screen.hasControlDown()) moveGroup(1);
-        if (previousItemKeyPressed.canBeTriggered() && Screen.hasControlDown()) moveGroup(-1);
+        if (KeyBindingsHandler.OBJECT_TRACKER_NEXT_ITEM.mapping.consumeClick()) {
+            if (!isNextItemKeyDown) {
+                isNextItemKeyDown = true;
+                if (isControlDown) {
+                    moveGroup(1);
+                } else {
+                    moveObject(1);
+                }
+            }
+        } else if (!KeyBindingsHandler.OBJECT_TRACKER_NEXT_ITEM.mapping.isDown()) {
+            isNextItemKeyDown = false;
+        }
 
-        if (nextItemKeyPressed.canBeTriggered() && !Screen.hasControlDown()) moveObject(1);
-        if (previousItemKeyPressed.canBeTriggered() && !Screen.hasControlDown()) moveObject(-1);
+        if (KeyBindingsHandler.OBJECT_TRACKER_PREVIOUS_ITEM.mapping.consumeClick()) {
+            if (!isPreviousItemKeyDown) {
+                isPreviousItemKeyDown = true;
+                if (isControlDown) {
+                    moveGroup(-1);
+                } else {
+                    moveObject(-1);
+                }
+            }
+        } else if (!KeyBindingsHandler.OBJECT_TRACKER_PREVIOUS_ITEM.mapping.isDown()) {
+            isPreviousItemKeyDown = false;
+        }
 
-        if (targetNearestObjectKeyPressed.canBeTriggered()) targetNearestObject();
+        if (KeyBindingsHandler.TARGET_NEAREST_OBJECT.mapping.consumeClick()) {
+            if (!isTargetNearestObjectKeyDown) {
+                isTargetNearestObjectKeyDown = true;
+                targetNearestObject();
+            }
+        } else if (!KeyBindingsHandler.TARGET_NEAREST_OBJECT.mapping.isDown()) {
+            isTargetNearestObjectKeyDown = false;
+        }
+
+        wasControlDownLastTick = Screen.hasControlDown();
     }
 
     private void updateGroups() {


### PR DESCRIPTION
This PR aims to end our usage of the KeyStroke, KeyInterval, and KeyUtils classes by just doing what literally every other mod does and using the built in logic and detection from the vanilla game.
# Changelog

## Feature Updates
- All bindable key mappings now use Mojang's built in system, removing much unneeded code from the mod