### PR TITLE
Add attack indicator sound

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/HUDStatus.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/HUDStatus.java
@@ -5,7 +5,11 @@ import java.util.List;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.LerpingBossEvent;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.resources.language.I18n;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.level.GameType;
 
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.mixin.BossHealthOverlayAccessor;
@@ -13,17 +17,14 @@ import org.mcaccess.minecraftaccess.utils.KeyBindingsHandler;
 
 public class HUDStatus {
     private Minecraft client = Minecraft.getInstance().getInstance();
-    private Boolean wasHidden = Minecraft.getInstance().options.hideGui;
+    private Boolean hudWasHidden = Minecraft.getInstance().options.hideGui;
+    private boolean attackCooldownPlayed = false;
     private boolean bossbarKeyIsDown = false;
     private int bossIndex = 0;
 
     public void tick() {
-        Boolean isHidden = client.options.hideGui;
-
-        if (wasHidden != isHidden) {
-            MainClass.narrate(I18n.get(String.format("minecraft_access.hud_status.announce_%s", isHidden ? "hidden" : "shown")), true);
-            wasHidden = isHidden;
-        }
+        hudVisibilityStatus();
+        attackCooldownStatus();
 
         if (KeyBindingsHandler.NARRATE_BOSSBARS_KEY.mapping.consumeClick()) {
             if (!bossbarKeyIsDown) {
@@ -32,6 +33,31 @@ public class HUDStatus {
             }
         } else if (!KeyBindingsHandler.NARRATE_BOSSBARS_KEY.mapping.isDown()) {
             bossbarKeyIsDown = false;
+        }
+    }
+
+    private void hudVisibilityStatus() {
+        Boolean hudIsHidden = client.options.hideGui;
+
+        if (hudWasHidden != hudIsHidden) {
+            MainClass.narrate(I18n.get(String.format("minecraft_access.hud_status.announce_%s", hudIsHidden ? "hidden" : "shown")), true);
+            hudWasHidden = hudIsHidden;
+        }
+    }
+
+    private void attackCooldownStatus() {
+        boolean indicatorShowing = !hudWasHidden && client.options.attackIndicator().get().getId() != 0 && client.gameMode.getPlayerMode() != GameType.SPECTATOR;
+        if (!indicatorShowing) return;
+
+        LocalPlayer player = client.player;
+        if (player == null) return;
+
+        float cooldownProgress = player.getAttackStrengthScale(1.0f);
+        if (!attackCooldownPlayed && cooldownProgress == 1.0f) {
+            player.playNotifySound(SoundEvents.WOODEN_PRESSURE_PLATE_CLICK_ON, SoundSource.PLAYERS, 1.0f, 1.0f);
+            attackCooldownPlayed = true;
+        } else if (attackCooldownPlayed && cooldownProgress < 1.0f) {
+            attackCooldownPlayed = false;
         }
     }
 

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/HUDStatus.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/HUDStatus.java
@@ -3,6 +3,7 @@ package org.mcaccess.minecraftaccess.features;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.minecraft.client.AttackIndicatorStatus;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.LerpingBossEvent;
 import net.minecraft.client.player.LocalPlayer;
@@ -46,7 +47,7 @@ public class HUDStatus {
     }
 
     private void attackCooldownStatus() {
-        boolean indicatorShowing = !hudWasHidden && client.options.attackIndicator().get().getId() != 0 && client.gameMode.getPlayerMode() != GameType.SPECTATOR;
+        boolean indicatorShowing = !hudWasHidden && client.options.attackIndicator().get() != AttackIndicatorStatus.OFF && client.gameMode.getPlayerMode() != GameType.SPECTATOR;
         if (!indicatorShowing) return;
 
         LocalPlayer player = client.player;
@@ -54,7 +55,7 @@ public class HUDStatus {
 
         float cooldownProgress = player.getAttackStrengthScale(1.0f);
         if (!attackCooldownPlayed && cooldownProgress == 1.0f) {
-            player.playNotifySound(SoundEvents.WOODEN_PRESSURE_PLATE_CLICK_ON, SoundSource.PLAYERS, 1.0f, 1.0f);
+            player.playNotifySound(SoundEvents.NOTE_BLOCK_HAT.value(), SoundSource.PLAYERS, 0.6f, 1.0f);
             attackCooldownPlayed = true;
         } else if (attackCooldownPlayed && cooldownProgress < 1.0f) {
             attackCooldownPlayed = false;

--- a/docs/content/sounds/index.md
+++ b/docs/content/sounds/index.md
@@ -47,11 +47,11 @@ Sounds can be played by pressing the play button.
 
 ## Misc Sounds
 
-| Description                                                                           | Sound                                                               |
-|---------------------------------------------------------------------------------------|---------------------------------------------------------------------|
-| Position with high drop-off                                                           | {{< wikiSound "Stone_dig1" >}} Foot stamping sound                  |
-| [Health], [hunger], [air], or [frost] reached the configured danger warning threshold | {{< wikiSound "Respawn_anchor_deplete1" >}} Shatter and woosh sound |
-| Plays when [attack indicator] is filled and is visible on screen                      | {{< wikiSound sound="Click" pitch=0.8 >}} Low pitched clunk sound   |
+| Description                                                                           | Sound                                                                       |
+|---------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| Position with high drop-off                                                           | {{< wikiSound "Stone_dig1" >}} Foot stamping sound                          |
+| [Health], [hunger], [air], or [frost] reached the configured danger warning threshold | {{< wikiSound "Respawn_anchor_deplete1" >}} Shatter and woosh sound         |
+| Plays when [attack indicator] is filled and is visible on screen                      | {{< wikiSound sound="Note_block_hat" pitch=1.0 >}} High pitched clack sound |
 
 ## Disclaimer
 

--- a/docs/content/sounds/index.md
+++ b/docs/content/sounds/index.md
@@ -45,17 +45,13 @@ Sounds can be played by pressing the play button.
 | Plays when target is visible, pitch indicates how much the bow is pulled  | {{< wikiSound "Note_block_pling" >}} Electric piano sound |
 | Plays when target is obscured, pitch indicates how much the bow is pulled | {{< wikiSound "Note_block_bass" >}} String bass sound     |
 
-## Fall Detector
-
-| Description                 | Sound                                              |
-|-----------------------------|----------------------------------------------------|
-| Position with high drop-off | {{< wikiSound "Stone_dig1" >}} Foot stamping sound |
-
-## Player Warnings
+## Misc Sounds
 
 | Description                                                                           | Sound                                                               |
 |---------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| Position with high drop-off                                                           | {{< wikiSound "Stone_dig1" >}} Foot stamping sound                  |
 | [Health], [hunger], [air], or [frost] reached the configured danger warning threshold | {{< wikiSound "Respawn_anchor_deplete1" >}} Shatter and woosh sound |
+| Plays when [attack indicator] is filled and is visible on screen                      | {{< wikiSound sound="Click" pitch=0.8 >}} Low pitched clunk sound   |
 
 ## Disclaimer
 
@@ -74,4 +70,5 @@ the [Minecraft Usage Guidelines] apply.
 [hunger]: https://minecraft.wiki/w/Hunger
 [air]: https://minecraft.wiki/w/Damage#Drowning
 [frost]: https://minecraft.wiki/w/Powder_Snow#Freezing
+[attack indicator]: https://minecraft.wiki/Cooldown
 [Minecraft Usage Guidelines]: https://www.minecraft.net/en-us/usage-guidelines


### PR DESCRIPTION
# Changelog

## New Features
- The attack cooldown indicator is now represented by a low-pitched clicking sound when it fills. This sound only plays if the indicator is visible on screen; to suppress it, either hide the HUD entirely or set the attack indicator to “Off” in the options menu.