### PR TITLE
Fix wrong i18n string for your pets group

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/BuiltinEntityPOIGroups.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/BuiltinEntityPOIGroups.java
@@ -33,7 +33,7 @@ public enum BuiltinEntityPOIGroups {
             }
     )),
     YOUR_PETS(new POIGroup<>(
-            "minecraft_access.point_of_interest.group.your_pets",
+            "minecraft_access.point_of_interest.group.your_pet",
             new POIGroup.Sound(SoundEvents.NOTE_BLOCK_FLUTE.value(), 1f),
             entity -> entity instanceof TamableAnimal pet && pet.isOwnedBy(WorldUtils.getClientPlayer())
     )),


### PR DESCRIPTION
[//]: # (This changelog will be part of the user-facing release notes)
[//]: # (Please keep anything that isn't part of the changelog above this line and delete unused headings)
[//]: # (Changelog entries should be formatted as unordered lists to ensure consistency when they are collated)

# Changelog

## Bug Fixes
- The "Your pets" POI group now uses the correct i18n string
