### PR TITLE
Categorize Allay as passive

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/BuiltinEntityPOIGroups.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/BuiltinEntityPOIGroups.java
@@ -5,6 +5,7 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.animal.WaterAnimal;
+import net.minecraft.world.entity.animal.allay.Allay;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 import net.minecraft.world.entity.boss.wither.WitherBoss;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -51,7 +52,7 @@ public enum BuiltinEntityPOIGroups {
             "minecraft_access.point_of_interest.group.passive",
             new POIGroup.Sound(SoundEvents.NOTE_BLOCK_BELL.value(), 0f),
             entity -> {
-                return (entity instanceof AgeableMob || entity instanceof WaterAnimal || entity instanceof NeutralMob) && !(entity.getPassengers().contains(Minecraft.getInstance().player));
+                return (entity instanceof AgeableMob || entity instanceof WaterAnimal || entity instanceof NeutralMob || entity instanceof Allay) && !(entity.getPassengers().contains(Minecraft.getInstance().player));
             }
     )),
     PLAYER(new POIGroup<>(// Players


### PR DESCRIPTION
# Changelog

## Bug Fixes
- Allays are now categorized as "passive" entities instead of falling through to the "other" category for sound queues and object tracking