### PR TITLE
Fixed usage of translated biome name for indicator comparison

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/BiomeIndicator.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/BiomeIndicator.java
@@ -10,6 +10,7 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import org.jetbrains.annotations.Nullable;
 
 import org.mcaccess.minecraftaccess.MainClass;
+import org.mcaccess.minecraftaccess.utils.NarrationUtils;
 
 /**
  * Narrates the name of the biome when entering a different biome.
@@ -31,22 +32,7 @@ public class BiomeIndicator {
         Holder<Biome> currentBiome = client.level.getBiome(client.player.blockPosition());
         if (currentBiome != previousBiome) {
             previousBiome = currentBiome;
-            String translatedBiome = I18n.get(getBiomeName(currentBiome));
-            MainClass.narrate(I18n.get("minecraft_access.other.biome", translatedBiome), true);
+            NarrationUtils.getTranslatedName(currentBiome, "biome").ifPresent(name -> MainClass.narrate(I18n.get("minecraft_access.other.biome", name), true));
         }
-    }
-
-    /**
-     * Gets the biome name from registry entry
-     *
-     * @param biome the biome's registry entry
-     * @return the biome's name
-     */
-    public static String getBiomeName(Holder<Biome> biome) {
-        String key = biome.unwrap().map(
-                (biomeKey) -> "biome." + biomeKey.location().getNamespace() + '.' + biomeKey.location().getPath(),
-                (biomeValue) -> "[unregistered " + biomeValue + ']' // For unregistered biome
-        );
-        return I18n.get(key);
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/BiomeIndicator.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/BiomeIndicator.java
@@ -3,8 +3,10 @@ package org.mcaccess.minecraftaccess.features;
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.language.I18n;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.chunk.LevelChunk;
 import org.jetbrains.annotations.Nullable;
 
 import org.mcaccess.minecraftaccess.MainClass;
@@ -15,20 +17,22 @@ import org.mcaccess.minecraftaccess.MainClass;
 @Slf4j
 public class BiomeIndicator {
     @Nullable
-    private String previousBiome = null;
+    private Holder<Biome> previousBiome = null;
 
     public void tick() {
-        Minecraft minecraftClient = Minecraft.getInstance();
-        if (minecraftClient.level == null) return;
-        if (minecraftClient.player == null) return;
-        if (minecraftClient.screen != null) return;
+        Minecraft client = Minecraft.getInstance();
+        if (client.level == null) return;
+        if (client.player == null) return;
+        if (client.screen != null) return;
+        BlockPos pos = client.player.blockPosition();
+        LevelChunk currentChunk = client.level.getChunkSource().getChunk(pos.getX() >> 4, pos.getZ() >> 4, false);
+        if (currentChunk == null) return;
 
-        Holder<Biome> biome = minecraftClient.level.getBiome(minecraftClient.player.blockPosition());
-        String name = I18n.get(getBiomeName(biome));
-
-        if (!name.equalsIgnoreCase(previousBiome)) {
-            previousBiome = name;
-            MainClass.narrate(I18n.get("minecraft_access.other.biome", name), true);
+        Holder<Biome> currentBiome = client.level.getBiome(client.player.blockPosition());
+        if (currentBiome != previousBiome) {
+            previousBiome = currentBiome;
+            String translatedBiome = I18n.get(getBiomeName(currentBiome));
+            MainClass.narrate(I18n.get("minecraft_access.other.biome", translatedBiome), true);
         }
     }
 
@@ -39,19 +43,10 @@ public class BiomeIndicator {
      * @return the biome's name
      */
     public static String getBiomeName(Holder<Biome> biome) {
-        return I18n.get(getBiomeTranslationKey(biome));
-    }
-
-    /**
-     * Gets the biome translation key from registry entry
-     *
-     * @param biome the biome's registry entry
-     * @return the biome's translation key
-     */
-    private static String getBiomeTranslationKey(Holder<Biome> biome) {
-        return biome.unwrap().map(
+        String key = biome.unwrap().map(
                 (biomeKey) -> "biome." + biomeKey.location().getNamespace() + '.' + biomeKey.location().getPath(),
                 (biomeValue) -> "[unregistered " + biomeValue + ']' // For unregistered biome
         );
+        return I18n.get(key);
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/access_menu/AccessMenu.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/access_menu/AccessMenu.java
@@ -176,8 +176,8 @@ public class AccessMenu {
 
         minecraftClient.player.clientSideCloseContainer();
 
-        Holder<Biome> var27 = minecraftClient.level.getBiome(minecraftClient.player.blockPosition());
-        String name = I18n.get(BiomeIndicator.getBiomeName(var27));
+        Holder<Biome> currentBiome = minecraftClient.level.getBiome(minecraftClient.player.blockPosition());
+        String name = I18n.get(BiomeIndicator.getBiomeName(currentBiome));
         MainClass.narrate(I18n.get("minecraft_access.access_menu.biome", name), true);
     }
 

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/access_menu/AccessMenu.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/access_menu/AccessMenu.java
@@ -18,7 +18,6 @@ import net.minecraft.world.phys.HitResult;
 
 import org.mcaccess.minecraftaccess.Config;
 import org.mcaccess.minecraftaccess.MainClass;
-import org.mcaccess.minecraftaccess.features.BiomeIndicator;
 import org.mcaccess.minecraftaccess.screen_reader.ScreenReaderController;
 import org.mcaccess.minecraftaccess.utils.KeyBindingsHandler;
 import org.mcaccess.minecraftaccess.utils.NarrationUtils;
@@ -177,8 +176,8 @@ public class AccessMenu {
         minecraftClient.player.clientSideCloseContainer();
 
         Holder<Biome> currentBiome = minecraftClient.level.getBiome(minecraftClient.player.blockPosition());
-        String name = I18n.get(BiomeIndicator.getBiomeName(currentBiome));
-        MainClass.narrate(I18n.get("minecraft_access.access_menu.biome", name), true);
+        NarrationUtils.getTranslatedName(currentBiome, "biome")
+                .ifPresent(name -> MainClass.narrate(I18n.get("minecraft_access.access_menu.biome", name), true));
     }
 
     public static void getXP() {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/utils/NarrationUtils.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/utils/NarrationUtils.java
@@ -70,7 +70,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.ComparatorMode;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
-import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.Vec3;
@@ -595,19 +594,10 @@ public final class NarrationUtils {
      */
     private static String narrateFluidBlock(BlockPos pos) {
         FluidState fluidState = WorldUtils.getClientWorld().getFluidState(pos);
-        String name = getFluidI18NName(fluidState.holder());
+        Optional<String> fluidName = getTranslatedName(fluidState.holder(), "block");
         int level = fluidState.getAmount();
         String levelString = level < 8 ? I18n.get("minecraft_access.read_crosshair.fluid_level", level) : "";
-        return name + ' ' + levelString;
-    }
-
-    private static String getFluidI18NName(Holder<Fluid> fluid) {
-        String translationKey = fluid.unwrap()
-                .map(
-                        fluidKey -> String.format("block.%s.%s", fluidKey.location().getNamespace(), fluidKey.location().getPath()),
-                        fluidValue -> "[unregistered " + fluidValue + ']'
-                );
-        return I18n.get(translationKey);
+        return fluidName.map(name -> String.format("%s %s", name, levelString)).orElse(levelString);
     }
 
     /**
@@ -636,5 +626,20 @@ public final class NarrationUtils {
         }
 
         return result.toString();
+    }
+
+    /**
+     * Gets the translated name from registry entry.
+     *
+     * @param holder the holder's registry entry
+     * @param type the type of holder you want the translated name for
+     * @return the holder's human readable name as an Optional
+     */
+    public static Optional<String> getTranslatedName(Holder<?> holder, String type) {
+        Optional<String> translatedName = holder.unwrapKey().map(key -> I18n.get(key.location().toLanguageKey(type)));
+        if (translatedName.isEmpty()) {
+            log.error("Failed to get a valid translation of the %s name".formatted(type));
+        }
+        return translatedName;
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/utils/NarrationUtils.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/utils/NarrationUtils.java
@@ -638,7 +638,7 @@ public final class NarrationUtils {
     public static Optional<String> getTranslatedName(Holder<?> holder, String type) {
         Optional<String> translatedName = holder.unwrapKey().map(key -> I18n.get(key.location().toLanguageKey(type)));
         if (translatedName.isEmpty()) {
-            log.error("Failed to get a valid translation of the %s name".formatted(type));
+            log.error("Failed to get a valid translation of the {} name", type);
         }
         return translatedName;
     }


### PR DESCRIPTION
# Changelog

## Bug Fixes
- Automatic biome narration will no longer trigger when the game's language is changed
- If a chunk is not fully loaded in, the automatic biome narration will no longer narrate the default biome for the dimention