### PR TITLE
Hypixel Skyblock Fixes

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/PlayerStatus.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/PlayerStatus.java
@@ -13,6 +13,7 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.level.GameType;
 
 import org.mcaccess.minecraftaccess.MainClass;
+import org.mcaccess.minecraftaccess.utils.HypixelSkyblockUtils;
 import org.mcaccess.minecraftaccess.utils.KeyBindingsHandler;
 import org.mcaccess.minecraftaccess.utils.NarrationUtils;
 import org.mcaccess.minecraftaccess.utils.condition.Interval;
@@ -67,6 +68,10 @@ public class PlayerStatus {
             GameType currentMode = client.gameMode.getPlayerMode();
 
             StringBuilder narration = new StringBuilder();
+
+            if (HypixelSkyblockUtils.isInServer() && !HypixelSkyblockUtils.lastStats.isEmpty()) {
+                narration.append(HypixelSkyblockUtils.lastStats).append(", ");
+            }
 
             if (currentMode == GameType.SURVIVAL || currentMode == GameType.ADVENTURE) {
                 if (!client.hasAltDown()) {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorMixin.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import org.mcaccess.minecraftaccess.MainClass;
+import org.mcaccess.minecraftaccess.utils.HypixelSkyblockUtils;
 import org.mcaccess.minecraftaccess.utils.NarratorDummy;
 
 @Mixin(GameNarrator.class)
@@ -23,6 +24,12 @@ abstract class GameNarratorMixin {
         if (MainClass.getScreenReader() == null || !MainClass.getScreenReader().isInitialized()) {
             return;
         }
+
+        if (HypixelSkyblockUtils.isInServer() && HypixelSkyblockUtils.checkForExclusion(text)) {
+            callbackInfo.cancel();
+            return;
+        }
+
         MainClass.getScreenReader().narrate(text, interrupt);
         callbackInfo.cancel();
     }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
@@ -20,7 +20,7 @@ import org.mcaccess.minecraftaccess.MainClass;
  * Narrates titles
  */
 @Mixin(Gui.class)
-public class GuiMixin {
+abstract class GuiMixin {
     @Shadow
     private Component title;
 

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
@@ -1,7 +1,6 @@
 package org.mcaccess.minecraftaccess.mixin;
 
-import java.util.Arrays;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.client.gui.Gui;
@@ -50,10 +49,10 @@ public class GuiMixin {
 
     @Unique
     private void onlyNarrateChangedParts(String msg) {
-        // Using only Assays.asList() will return an immutable array which throws "UnsupportedOperationException"
-        // https://stackoverflow.com/a/2965808
-        List<String> parts = new LinkedList<>(Arrays.asList(splitToParts(msg)));
-        List<String> previousParts = new LinkedList<>(Arrays.asList(splitToParts(previousActionBarContent)));
+        // Using only Arrays.asList() will return an immutable array which throws "UnsupportedOperationException"
+        // https://stackoverflow.com/a/2965808 (apparently LinkedList doesn't work either, ArrayList works though)
+        List<String> parts = new ArrayList<>(List.of(splitToParts(msg)));
+        List<String> previousParts = new ArrayList<>(List.of(splitToParts(previousActionBarContent)));
         parts.removeAll(previousParts);
         String narration = String.join(", ", parts);
         MainClass.narrate(narration, true);

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
@@ -1,6 +1,7 @@
 package org.mcaccess.minecraftaccess.mixin;
 
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 import net.minecraft.client.gui.Gui;
@@ -20,7 +21,7 @@ import org.mcaccess.minecraftaccess.MainClass;
  * Narrates titles
  */
 @Mixin(Gui.class)
-abstract class GuiMixin {
+public class GuiMixin {
     @Shadow
     private Component title;
 
@@ -49,8 +50,10 @@ abstract class GuiMixin {
 
     @Unique
     private void onlyNarrateChangedParts(String msg) {
-        List<String> parts = Arrays.asList(splitToParts(msg));
-        List<String> previousParts = Arrays.asList(splitToParts(previousActionBarContent));
+        // Using only Assays.asList() will return an immutable array which throws "UnsupportedOperationException"
+        // https://stackoverflow.com/a/2965808
+        List<String> parts = new LinkedList<>(Arrays.asList(splitToParts(msg)));
+        List<String> previousParts = new LinkedList<>(Arrays.asList(splitToParts(previousActionBarContent)));
         parts.removeAll(previousParts);
         String narration = String.join(", ", parts);
         MainClass.narrate(narration, true);

--- a/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderInterface.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderInterface.java
@@ -24,10 +24,4 @@ public interface ScreenReaderInterface {
      * Closes the screen reader
      */
     void closeScreenReader();
-
-    default String formatNarration(String text) {
-        // Remove formatting codes
-        // ref: https://minecraft.wiki/w/Formatting_codes
-        return text.replaceAll("§.", "");
-    }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderLinux.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderLinux.java
@@ -12,6 +12,8 @@ import com.sun.jna.Native;
 import com.sun.jna.Structure;
 import lombok.extern.slf4j.Slf4j;
 
+import static org.mcaccess.minecraftaccess.utils.TextUtils.removeFormattingCodes;
+
 @Slf4j
 public class ScreenReaderLinux implements ScreenReaderInterface {
     private LibSpeechdWrapperInterface mainInstance = null;
@@ -58,7 +60,7 @@ public class ScreenReaderLinux implements ScreenReaderInterface {
             return;
         }
 
-        String narration = formatNarration(text);
+        String narration = removeFormattingCodes(text);
 
         LibSpeechdWrapperInterface.GoString.ByValue str = new LibSpeechdWrapperInterface.GoString.ByValue();
         str.p = narration;

--- a/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderLinux.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderLinux.java
@@ -12,7 +12,7 @@ import com.sun.jna.Native;
 import com.sun.jna.Structure;
 import lombok.extern.slf4j.Slf4j;
 
-import static org.mcaccess.minecraftaccess.utils.TextUtils.removeFormattingCodes;
+import static org.mcaccess.minecraftaccess.utils.NarrationUtils.removeFormattingCodes;
 
 @Slf4j
 public class ScreenReaderLinux implements ScreenReaderInterface {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderMacOS.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderMacOS.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.mcaccess.minecraftaccess.Config;
 
+import static org.mcaccess.minecraftaccess.utils.TextUtils.removeFormattingCodes;
+
 @Slf4j
 public class ScreenReaderMacOS implements ScreenReaderInterface {
     private ObjcRuntimeInterface objcRuntimeInstance = null;
@@ -43,7 +45,7 @@ public class ScreenReaderMacOS implements ScreenReaderInterface {
             return;
         }
 
-        String narration = formatNarration(text);
+        String narration = removeFormattingCodes(text);
 
         if (interrupt) {
             // Stop speech immediately

--- a/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderMacOS.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderMacOS.java
@@ -7,7 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.mcaccess.minecraftaccess.Config;
 
-import static org.mcaccess.minecraftaccess.utils.TextUtils.removeFormattingCodes;
+import static org.mcaccess.minecraftaccess.utils.NarrationUtils.removeFormattingCodes;
 
 @Slf4j
 public class ScreenReaderMacOS implements ScreenReaderInterface {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderWindows.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderWindows.java
@@ -8,7 +8,7 @@ import com.sun.jna.Library;
 import com.sun.jna.Native;
 import lombok.extern.slf4j.Slf4j;
 
-import static org.mcaccess.minecraftaccess.utils.TextUtils.removeFormattingCodes;
+import static org.mcaccess.minecraftaccess.utils.NarrationUtils.removeFormattingCodes;
 
 @Slf4j
 public class ScreenReaderWindows implements ScreenReaderInterface {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderWindows.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/screen_reader/ScreenReaderWindows.java
@@ -8,6 +8,8 @@ import com.sun.jna.Library;
 import com.sun.jna.Native;
 import lombok.extern.slf4j.Slf4j;
 
+import static org.mcaccess.minecraftaccess.utils.TextUtils.removeFormattingCodes;
+
 @Slf4j
 public class ScreenReaderWindows implements ScreenReaderInterface {
     TolkInterface mainInstance = null;
@@ -44,7 +46,7 @@ public class ScreenReaderWindows implements ScreenReaderInterface {
             return;
         }
 
-        String narration = formatNarration(text);
+        String narration = removeFormattingCodes(text);
 
         char[] ch = new char[narration.length() + 1];  // Last character must be null so NVDA decodes the text correctly
         for (int i = 0; i < narration.length(); i++) {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/utils/HypixelSkyblockUtils.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/utils/HypixelSkyblockUtils.java
@@ -1,0 +1,45 @@
+package org.mcaccess.minecraftaccess.utils;
+
+import java.util.regex.Pattern;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.language.I18n;
+
+import org.mcaccess.minecraftaccess.MainClass;
+
+public final class HypixelSkyblockUtils {
+    // https://regex101.com/r/hgCXM2/1
+    private static final Pattern STATS_REGEX = Pattern.compile(".*❤.*❈ Defense.*✎ Mana", Pattern.MULTILINE);
+    private static final Pattern LOCATION_REGEX = Pattern.compile(".*❤.*⏣(\\D*)\\d*/\\d*✎ Mana", Pattern.MULTILINE);
+    private static final String LOCATION_REGEX_SUBSTITUTE = "$1";
+
+    public static String lastStats = null;
+    public static String lastLocation = null;
+
+    private HypixelSkyblockUtils() {
+    }
+
+    public static boolean isInServer() {
+        return Minecraft.getInstance().getCurrentServer() != null
+                && Minecraft.getInstance().getCurrentServer().ip.equalsIgnoreCase("mc.hypixel.net");
+    }
+
+    public static boolean checkForExclusion(String text) {
+        String formattedText = TextUtils.removeFormattingCodes(text);
+        if (STATS_REGEX.matcher(formattedText).matches()) {
+            lastStats = formattedText;
+            return true;
+        }
+
+        if (LOCATION_REGEX.matcher(formattedText).matches()) {
+            String loc = LOCATION_REGEX.matcher(formattedText).replaceAll(LOCATION_REGEX_SUBSTITUTE);
+            if (!loc.equals(lastLocation)) {
+                lastLocation = loc;
+                MainClass.narrate(I18n.get("minecraft_access.other.hypixel_skyblock_area_entered", lastLocation), true);
+            }
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/common/src/main/java/org/mcaccess/minecraftaccess/utils/HypixelSkyblockUtils.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/utils/HypixelSkyblockUtils.java
@@ -13,6 +13,9 @@ public final class HypixelSkyblockUtils {
     private static final Pattern LOCATION_REGEX = Pattern.compile(".*❤.*⏣(\\D*)\\d*/\\d*✎ Mana", Pattern.MULTILINE);
     private static final String LOCATION_REGEX_SUBSTITUTE = "$1";
 
+    private static String lastServerIp = null;
+    private static boolean lastServerIsHypixel = false;
+
     public static String lastStats = null;
     public static String lastLocation = null;
 
@@ -20,8 +23,11 @@ public final class HypixelSkyblockUtils {
     }
 
     public static boolean isInServer() {
-        return Minecraft.getInstance().getCurrentServer() != null
-                && Minecraft.getInstance().getCurrentServer().ip.equalsIgnoreCase("mc.hypixel.net");
+        if (Minecraft.getInstance().getCurrentServer() == null) return false;
+        if (Minecraft.getInstance().getCurrentServer().ip.equals(lastServerIp)) return lastServerIsHypixel;
+        lastServerIp = Minecraft.getInstance().getCurrentServer().ip;
+        lastServerIsHypixel = lastServerIp.endsWith("hypixel.net");
+        return lastServerIsHypixel;
     }
 
     public static boolean checkForExclusion(String text) {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/utils/HypixelSkyblockUtils.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/utils/HypixelSkyblockUtils.java
@@ -31,7 +31,7 @@ public final class HypixelSkyblockUtils {
     }
 
     public static boolean checkForExclusion(String text) {
-        String formattedText = TextUtils.removeFormattingCodes(text);
+        String formattedText = NarrationUtils.removeFormattingCodes(text);
         if (STATS_REGEX.matcher(formattedText).matches()) {
             lastStats = formattedText;
             return true;

--- a/common/src/main/java/org/mcaccess/minecraftaccess/utils/NarrationUtils.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/utils/NarrationUtils.java
@@ -708,4 +708,10 @@ public final class NarrationUtils {
         });
         return builder.toString();
     }
+
+    public static String removeFormattingCodes(String text) {
+        // Remove formatting codes
+        // ref: https://minecraft.wiki/w/Formatting_codes
+        return text.replaceAll("§.", "");
+    }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/utils/TextUtils.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/utils/TextUtils.java
@@ -1,9 +1,0 @@
-package org.mcaccess.minecraftaccess.utils;
-
-public final class TextUtils {
-    public static String removeFormattingCodes(String text) {
-        // Remove formatting codes
-        // ref: https://minecraft.wiki/w/Formatting_codes
-        return text.replaceAll("§.", "");
-    }
-}

--- a/common/src/main/java/org/mcaccess/minecraftaccess/utils/TextUtils.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/utils/TextUtils.java
@@ -1,0 +1,9 @@
+package org.mcaccess.minecraftaccess.utils;
+
+public final class TextUtils {
+    public static String removeFormattingCodes(String text) {
+        // Remove formatting codes
+        // ref: https://minecraft.wiki/w/Formatting_codes
+        return text.replaceAll("§.", "");
+    }
+}

--- a/common/src/main/resources/assets/minecraft_access/lang/en_us.json
+++ b/common/src/main/resources/assets/minecraft_access/lang/en_us.json
@@ -131,6 +131,7 @@
     "minecraft_access.other.end_of_list": "End of list",
     "minecraft_access.other.entity_with_equipments": "{entity} with {equipments}",
     "minecraft_access.other.facing_direction": "Facing %s",
+    "minecraft_access.other.hypixel_skyblock_area_entered": "%s entered",
     "minecraft_access.other.missing": "Missing",
     "minecraft_access.other.negative": "negative %s",
     "minecraft_access.other.no_bossbars": "No bossbars visible",


### PR DESCRIPTION
# Changelog

## Feature Updates

- Added narration exclusions for hypixel skyblock.
    - specifically the health-defence-mana text is suppressed. This text is also cached and spoken when the player stats keybind is used
    - also the health-area-mana text is suppressed and only area is spoken with the "entered" suffix.

## Bug Fixes

- Fixed crash when joining hypixel skyblock.

## Others

- Moved `ScreenReaderInterface.formatNarration` to `NarrationUtils.removeFormattingCodes`.
- Added i18n entry: `minecraft_access.other.hypixel_skyblock_area_entered`

