### PR TITLE
Name the Checkstyle report

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,6 +20,7 @@ jobs:
           reporter: ${{ github.event_name == 'push' && 'github-check' || 'github-pr-check' }}
           filter_mode: ${{ github.event_name == 'push' && 'nofilter' || 'added' }}
           fail_level: error
+          reviewdog_flags: "--name=Checkstyle Report"
 
   translation-sorting:
     name: Translation File Sorting


### PR DESCRIPTION
This PR changes the name of the Checkstyle Report to clarify it for screen reader users, as previously, the only change was the capitalization of the letter c, which isn't picked up by screen readers unless the user traverses letter by letter.