### PR TITLE
Fixed in screen key handling

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/MouseKeySimulation.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/MouseKeySimulation.java
@@ -2,10 +2,14 @@ package org.mcaccess.minecraftaccess.features;
 
 import java.util.Set;
 
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
 import net.minecraft.util.Tuple;
 import org.apache.commons.lang3.tuple.Triple;
 
 import org.mcaccess.minecraftaccess.Config;
+import org.mcaccess.minecraftaccess.mixin.KeyMappingAccessor;
 import org.mcaccess.minecraftaccess.utils.KeyBindingsHandler;
 import org.mcaccess.minecraftaccess.utils.condition.Interval;
 import org.mcaccess.minecraftaccess.utils.condition.IntervalKeystroke;
@@ -17,9 +21,9 @@ import org.mcaccess.minecraftaccess.utils.system.MouseUtils;
  */
 public final class MouseKeySimulation {
     private static final Keystroke[] MOUSE_CLICKS = new Keystroke[]{
-            new Keystroke(() -> KeyBindingsHandler.Keys.MOUSE_SIMULATION_LEFT_MOUSE_KEY.mapping.isDown()),
-            new Keystroke(() -> KeyBindingsHandler.Keys.MOUSE_SIMULATION_MIDDLE_MOUSE_KEY.mapping.isDown()),
-            new Keystroke(() -> KeyBindingsHandler.Keys.MOUSE_SIMULATION_RIGHT_MOUSE_KEY.mapping.isDown()),
+            new Keystroke(() -> isKeyPressed(KeyBindingsHandler.Keys.MOUSE_SIMULATION_LEFT_MOUSE_KEY.mapping)),
+            new Keystroke(() -> isKeyPressed(KeyBindingsHandler.Keys.MOUSE_SIMULATION_MIDDLE_MOUSE_KEY.mapping)),
+            new Keystroke(() -> isKeyPressed(KeyBindingsHandler.Keys.MOUSE_SIMULATION_RIGHT_MOUSE_KEY.mapping)),
     };
     public static final Set<Triple<Keystroke, Runnable, Runnable>> MOUSE_CLICK_ACTIONS = Set.of(
             Triple.of(MOUSE_CLICKS[0], MouseUtils.Key.LEFT::press, MouseUtils.Key.LEFT::release),
@@ -59,5 +63,11 @@ public final class MouseKeySimulation {
                 t.getRight().run();
             }
         });
+    }
+
+    private static boolean isKeyPressed(KeyMapping keyMapping) {
+        if (keyMapping.isUnbound()) return false;
+
+        return InputConstants.isKeyDown(Minecraft.getInstance().getWindow(), ((KeyMappingAccessor) keyMapping).getKey().getValue());
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/access_menu/AccessMenu.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/access_menu/AccessMenu.java
@@ -86,7 +86,7 @@ public class AccessMenu {
         if (CLIENT.player == null) return;
 
         if (CLIENT.screen == null) {
-            if (Minecraft.getInstance().hasAltDown()) {
+            if (CLIENT.hasAltDown()) {
                 handleInMenuActions();
                 return;
             }
@@ -102,7 +102,6 @@ public class AccessMenu {
                 CLIENT.setScreen(new AccessMenuGUI());
             }
         } else if (CLIENT.screen instanceof AccessMenuGUI) {
-            if (MENU_KEY.closeMenuIfMenuKeyPressing()) return;
             handleInMenuActions();
         }
 

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/access_menu/AccessMenuGUI.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/access_menu/AccessMenuGUI.java
@@ -6,12 +6,14 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.layouts.GridLayout;
 import net.minecraft.client.gui.layouts.HeaderAndFooterLayout;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 
 import org.mcaccess.minecraftaccess.Config;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.screen_reader.ScreenReaderController;
+import org.mcaccess.minecraftaccess.utils.KeyBindingsHandler;
 
 /**
  * GUI screen for the access menu.
@@ -74,5 +76,14 @@ public class AccessMenuGUI extends Screen {
         rowHelper.addChild(Button.builder(label, pressAction)
                 .width(Math.min(250, width / 2 - 15))
                 .build());
+    }
+
+    @Override
+    public boolean keyPressed(KeyEvent event) {
+        if (KeyBindingsHandler.Keys.ACCESS_MENU_KEY.mapping.matches(event)) {
+            Minecraft.getInstance().player.clientSideCloseContainer();
+            return true;
+        }
+        return super.keyPressed(event);
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/InventoryControls.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/InventoryControls.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import lombok.extern.slf4j.Slf4j;
+import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.components.StateSwitchingButton;
@@ -39,6 +40,7 @@ import org.mcaccess.minecraftaccess.mixin.AbstractRecipeBookScreenAccessor;
 import org.mcaccess.minecraftaccess.mixin.AnvilScreenAccessor;
 import org.mcaccess.minecraftaccess.mixin.CreativeModeInventoryScreenAccessor;
 import org.mcaccess.minecraftaccess.mixin.EditBoxAccessor;
+import org.mcaccess.minecraftaccess.mixin.KeyMappingAccessor;
 import org.mcaccess.minecraftaccess.mixin.RecipeBookComponentAccessor;
 import org.mcaccess.minecraftaccess.mixin.RecipeBookPageAccessor;
 import org.mcaccess.minecraftaccess.utils.KeyBindingsHandler;
@@ -178,13 +180,13 @@ public class InventoryControls {
      * Handles the key inputs.
      */
     private boolean keyListener() {
-        boolean isGroupKeyPressed = KeyBindingsHandler.Keys.INVENTORY_CONTROLS_GROUP_KEY.mapping.isDown();
-        boolean isUpKeyPressed = KeyBindingsHandler.Keys.INVENTORY_CONTROLS_UP_KEY.mapping.isDown();
-        boolean isRightKeyPressed = KeyBindingsHandler.Keys.INVENTORY_CONTROLS_RIGHT_KEY.mapping.isDown();
-        boolean isDownKeyPressed = KeyBindingsHandler.Keys.INVENTORY_CONTROLS_DOWN_KEY.mapping.isDown();
-        boolean isLeftKeyPressed = KeyBindingsHandler.Keys.INVENTORY_CONTROLS_LEFT_KEY.mapping.isDown();
-        boolean isSwitchTabKeyPressed = KeyBindingsHandler.Keys.INVENTORY_CONTROLS_SWITCH_TAB_KEY.mapping.isDown();
-        boolean isToggleCraftableKeyPressed = KeyBindingsHandler.Keys.INVENTORY_CONTROLS_TOGGLE_CRAFTABLE_KEY.mapping.isDown();
+        boolean isGroupKeyPressed = isKeyPressed(KeyBindingsHandler.Keys.INVENTORY_CONTROLS_GROUP_KEY.mapping);
+        boolean isUpKeyPressed = isKeyPressed(KeyBindingsHandler.Keys.INVENTORY_CONTROLS_UP_KEY.mapping);
+        boolean isRightKeyPressed = isKeyPressed(KeyBindingsHandler.Keys.INVENTORY_CONTROLS_RIGHT_KEY.mapping);
+        boolean isDownKeyPressed = isKeyPressed(KeyBindingsHandler.Keys.INVENTORY_CONTROLS_DOWN_KEY.mapping);
+        boolean isLeftKeyPressed = isKeyPressed(KeyBindingsHandler.Keys.INVENTORY_CONTROLS_LEFT_KEY.mapping);
+        boolean isSwitchTabKeyPressed = isKeyPressed(KeyBindingsHandler.Keys.INVENTORY_CONTROLS_SWITCH_TAB_KEY.mapping);
+        boolean isToggleCraftableKeyPressed = isKeyPressed(KeyBindingsHandler.Keys.INVENTORY_CONTROLS_TOGGLE_CRAFTABLE_KEY.mapping);
         boolean isEnterPressed = InputConstants.isKeyDown(client.getWindow(), InputConstants.KEY_RETURN)
                 || InputConstants.isKeyDown(client.getWindow(), InputConstants.KEY_NUMPADENTER);
         boolean isTPressed = InputConstants.isKeyDown(client.getWindow(), InputConstants.KEY_T);
@@ -321,6 +323,12 @@ public class InventoryControls {
         }
 
         return false;
+    }
+
+    private boolean isKeyPressed(KeyMapping keyMapping) {
+        if (keyMapping.isUnbound()) return false;
+
+        return InputConstants.isKeyDown(client.getWindow(), ((KeyMappingAccessor) keyMapping).getKey().getValue());
     }
 
     private boolean recipeBookIsOpening() {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/utils/condition/IntervalKeystroke.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/utils/condition/IntervalKeystroke.java
@@ -2,7 +2,11 @@ package org.mcaccess.minecraftaccess.utils.condition;
 
 import java.util.function.BooleanSupplier;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+
+import org.mcaccess.minecraftaccess.mixin.KeyMappingAccessor;
 
 
 /**
@@ -13,7 +17,9 @@ public class IntervalKeystroke extends TimedKeystroke {
      * Single key, {@link TriggeredAt#PRESSING}
      */
     public IntervalKeystroke(KeyMapping singleKey) {
-        this(() -> singleKey.isDown(), TriggeredAt.PRESSING);
+        this(() ->
+                        InputConstants.isKeyDown(Minecraft.getInstance().getWindow(), ((KeyMappingAccessor) singleKey).getKey().getValue()),
+                TriggeredAt.PRESSING);
     }
 
     /**


### PR DESCRIPTION
This pull request fixes a regression introduced in #659 where keys that are evaluated in screens were not being handled by the mod anymore to trigger functionality.