### PR TITLE
Fix actions scans and bump FAPI/Neo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,16 +6,16 @@ plugins {
 
 def git = versionDetails()
 def tag = git.lastTag.substring(1)
-if (System.getenv("GITHUB_ACTIONS") == "true") {
-    if (System.getenv("GITHUB_WORKFLOW") == "Release") {
+if (System.getenv('GITHUB_ACTIONS') == 'true') {
+    if (System.getenv('GITHUB_WORKFLOW') == 'Release') {
         version = tag
-    } else if (System.getenv("PULL_REQUEST")) {
-        version = "${tag}${tag.contains("-") ? "." : "-"}SNAPSHOT.pr.${System.getenv("PULL_REQUEST")}.${System.getenv("GITHUB_RUN_NUMBER")}"
+    } else if (System.getenv('PULL_REQUEST')) {
+        version = "${tag}${tag.contains('-') ? '.' : '-'}SNAPSHOT.pr.${System.getenv('PULL_REQUEST')}.${System.getenv('GITHUB_RUN_NUMBER')}"
     } else {
-        version = "${tag}${tag.contains("-") ? "." : "-"}SNAPSHOT.${System.getenv("GITHUB_RUN_NUMBER")}"
+        version = "${tag}${tag.contains('-') ? '.' : '-'}SNAPSHOT.${System.getenv('GITHUB_RUN_NUMBER')}"
     }
 } else {
-    version = "${tag}${tag.contains("-") ? "." : "-"}SNAPSHOT"
+    version = "${tag}${tag.contains('-') ? '.' : '-'}SNAPSHOT"
 }
 
 architectury {
@@ -44,7 +44,7 @@ subprojects {
         mappings loom.layered() {
             officialMojangMappings()
             parchment variantOf(libs.parchment) {
-                artifactType("zip")
+                artifactType('zip')
             }
         }
     }
@@ -66,9 +66,9 @@ subprojects {
         }
         maven {
             name = 'Twelve Iterations'
-            url "https://maven.twelveiterations.com/repository/maven-public/"
+            url = 'https://maven.twelveiterations.com/repository/maven-public/'
             content {
-                includeGroup "net.blay09.mods"
+                includeGroup 'net.blay09.mods'
             }
         }
         exclusiveContent {
@@ -86,17 +86,17 @@ subprojects {
 }
 
 allprojects {
-    apply plugin: "java"
+    apply plugin: 'java'
     apply plugin: libs.plugins.architecturyPlugin.get().pluginId
-    apply plugin: "maven-publish"
+    apply plugin: 'maven-publish'
     apply plugin: 'checkstyle'
 
     base.archivesName = 'minecraft-access'
 
-    group = "org.mcaccess.minecraftaccess"
+    group = 'org.mcaccess.minecraftaccess'
 
     tasks.withType(JavaCompile).configureEach {
-        options.encoding = "UTF-8"
+        options.encoding = 'UTF-8'
         options.release = 21
     }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,5 +1,5 @@
 architectury {
-    common("fabric", "neoforge")
+    common('fabric', 'neoforge')
 }
 
 idea {
@@ -36,5 +36,5 @@ test {
     useJUnitPlatform()
     // Suppress JVM warning about mockito's behavior when running unit tests with IntelliJ
     // ref: https://stackoverflow.com/questions/77951485/getting-a-java-agent-has-been-loaded-warning-in-intellij-after-upgrading-jdk-17
-    jvmArgs("-XX:+EnableDynamicAgentLoading")
+    jvmArgs('-XX:+EnableDynamicAgentLoading')
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -8,7 +8,7 @@ architectury {
 }
 
 loom {
-    log4jConfigs.from(file("../log4j.xml"))
+    log4jConfigs.from(file('../log4j.xml'))
 }
 
 configurations {
@@ -33,15 +33,15 @@ dependencies {
 
     modImplementation libs.modMenu
 
-    common(project(path: ":common", configuration: "namedElements")) { transitive = false }
-    shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) { transitive = false }
+    common(project(path: ':common', configuration: 'namedElements')) { transitive = false }
+    shadowCommon(project(path: ':common', configuration: 'transformProductionFabric')) { transitive = false }
 }
 
 processResources {
     def modVersion = project.version.toString()
-    inputs.property "version", modVersion
+    inputs.property 'version', modVersion
 
-    filesMatching("fabric.mod.json") {
+    filesMatching('fabric.mod.json') {
         expand(
                 version: modVersion,
                 fabric_loader_version: libs.fabricLoader.get().version,
@@ -56,7 +56,7 @@ processResources {
 
 shadowJar {
     configurations = [project.configurations.shadowCommon]
-    archiveClassifier = "dev-shadow"
+    archiveClassifier = 'dev-shadow'
 }
 
 remapJar {
@@ -66,11 +66,11 @@ remapJar {
 }
 
 jar {
-    archiveClassifier = "dev"
+    archiveClassifier = 'dev'
 }
 
 sourcesJar {
-    def commonSources = project(":common").sourcesJar
+    def commonSources = project(':common').sourcesJar
     dependsOn commonSources
     from commonSources.archiveFile.map {
         zipTree(it)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,14 +16,14 @@ balmNeoForge = { module = "net.blay09.mods:balm-neoforge", version.ref = "balm" 
 clothConfig = { module = "me.shedaniel.cloth:cloth-config", version.ref = "clothConfig" }
 clothConfigFabric = { module = "me.shedaniel.cloth:cloth-config-fabric", version.ref = "clothConfig" }
 clothConfigNeoForge = { module = "me.shedaniel.cloth:cloth-config-neoforge", version.ref = "clothConfig" }
-fabricApi = "net.fabricmc.fabric-api:fabric-api:0.138.0+1.21.10"
+fabricApi = "net.fabricmc.fabric-api:fabric-api:0.138.3+1.21.10"
 fabricLoader = "net.fabricmc:fabric-loader:0.17.3"
 jadeFabric = "maven.modrinth:jade:20.1.0+fabric"
 jadeNeoForge = "maven.modrinth:jade:20.0.5+neoforge"
 lombok = "org.projectlombok:lombok:1.18.42"
 minecraft = "com.mojang:minecraft:1.21.10"
 modMenu = "com.terraformersmc:modmenu:16.0.0-rc.1"
-neoForge = "net.neoforged:neoforge:21.10.49-beta"
+neoForge = "net.neoforged:neoforge:21.10.50-beta"
 parchment = "org.parchmentmc.data:parchment-1.21.10:2025.10.12"
 
 assertjCore = "org.assertj:assertj-core:3.27.6"

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -8,7 +8,7 @@ architectury {
 }
 
 loom {
-    log4jConfigs.from(file("../log4j.xml"))
+    log4jConfigs.from(file('../log4j.xml'))
 }
 
 configurations {
@@ -28,15 +28,15 @@ dependencies {
     modImplementation libs.clothConfigNeoForge
     include libs.clothConfigNeoForge
 
-    common(project(path: ":common", configuration: "namedElements")) { transitive = false }
-    shadowCommon(project(path: ":common", configuration: "transformProductionNeoForge")) { transitive = false }
+    common(project(path: ':common', configuration: 'namedElements')) { transitive = false }
+    shadowCommon(project(path: ':common', configuration: 'transformProductionNeoForge')) { transitive = false }
 }
 
 processResources {
     def modVersion = project.version.toString()
-    inputs.property "version", modVersion
+    inputs.property 'version', modVersion
 
-    filesMatching("META-INF/neoforge.mods.toml") {
+    filesMatching('META-INF/neoforge.mods.toml') {
         expand(
                 version: modVersion,
                 neoforge_version: libs.neoForge.get().version,
@@ -49,10 +49,10 @@ processResources {
 }
 
 shadowJar {
-    exclude "fabric.mod.json"
+    exclude 'fabric.mod.json'
 
     configurations = [project.configurations.shadowCommon]
-    archiveClassifier = "dev-shadow"
+    archiveClassifier = 'dev-shadow'
 }
 
 remapJar {
@@ -62,11 +62,11 @@ remapJar {
 }
 
 jar {
-    archiveClassifier = "dev"
+    archiveClassifier = 'dev'
 }
 
 sourcesJar {
-    def commonSources = project(":common").sourcesJar
+    def commonSources = project(':common').sourcesJar
     dependsOn commonSources
     from commonSources.archiveFile.map {
         zipTree(it)

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,9 +14,9 @@ pluginManagement {
         }
         maven {
             name = 'Twelve Iterations'
-            url "https://maven.twelveiterations.com/repository/maven-public/"
+            url = 'https://maven.twelveiterations.com/repository/maven-public/'
             content {
-                includeGroup "net.blay09.mods"
+                includeGroup 'net.blay09.mods'
             }
         }
         gradlePluginPortal()
@@ -29,7 +29,7 @@ plugins {
 
 develocity {
     buildScan {
-        publishing.onlyIf { System.getenv("GITHUB_ACTIONS") == "true" }
+        publishing.onlyIf { System.getenv('GITHUB_ACTIONS') == 'true' }
     }
 }
 
@@ -40,7 +40,7 @@ dependencyResolutionManagement {
             url = 'https://maven.architectury.dev'
         }
         mavenCentral()
-        maven{
+        maven {
             name = 'Cloth Config'
             url = 'https://maven.shedaniel.me/'
         }
@@ -74,8 +74,8 @@ dependencyResolutionManagement {
     }
 }
 
-include("common")
-include("fabric")
-include("neoforge")
+include('common')
+include('fabric')
+include('neoforge')
 
-rootProject.name = "minecraft_access"
+rootProject.name = 'minecraft_access'

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,7 +30,6 @@ plugins {
 develocity {
     buildScan {
         publishing.onlyIf { System.getenv("GITHUB_ACTIONS") == "true" }
-        tag(System.getenv("GITHUB_REF_NAME"))
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,8 @@ plugins {
 
 develocity {
     buildScan {
-        publishing.onlyIf { false }
+        publishing.onlyIf { System.getenv("GITHUB_ACTIONS") == "true" }
+        tag(System.getenv("GITHUB_REF_NAME"))
     }
 }
 


### PR DESCRIPTION
This build fixes the automatic build scans that should be published when GH actions runs. It also bumps Fabric API to the correct latest version, as well as NeoForge. Fabric Loader was skipped, as it is still in a beta state.