### PR TITLE
Updated cloth and parchment

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@
 
 [versions]
 balm = "21.11.2"
-clothConfig = "21.11.151"
+clothConfig = "21.11.152"
 jmh = "1.37"
 junit = "6.0.1"
 mockito = "5.21.0"
@@ -24,8 +24,8 @@ jadeNeoForge = "maven.modrinth:jade:21.0.1+neoforge"
 lombok = "org.projectlombok:lombok:1.18.42"
 minecraft = "com.mojang:minecraft:1.21.11"
 modMenu = "com.terraformersmc:modmenu:17.0.0-alpha.1"
-neoForge = "net.neoforged:neoforge:21.11.10-beta"
-parchment = "org.parchmentmc.data:parchment-1.21.10:2025.10.12"
+neoForge = "net.neoforged:neoforge:21.11.12-beta"
+parchment = "org.parchmentmc.data:parchment-1.21.11:2025.12.20"
 tolk = "com.davykager.tolk:Tolk:1.0.0"
 
 assertjCore = "org.assertj:assertj-core:3.27.6"


### PR DESCRIPTION
Bumps parchment, cloth, and NeoForge. This was done manually due to the fact that new Minecraft releases need new parchment coordinates.