### PR TITLE
Make POI Marker use current object tracker object

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/ObjectTracker.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/ObjectTracker.java
@@ -241,7 +241,7 @@ public class ObjectTracker implements BalmClientModule {
         POIGroup<?> nextGroup = groups.get(newIndex);
 
         while ((nextGroup.isEmpty()
-            || nextGroup.sortByDistance().stream().noneMatch(this::isObjectValid))
+                || nextGroup.sortByDistance().stream().noneMatch(this::isObjectValid))
                 && newIndex + step >= 0
                 && newIndex + step < groups.size()) {
             newIndex += step;

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/POIBlocks.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/POIBlocks.java
@@ -3,6 +3,7 @@ package org.mcaccess.minecraftaccess.features.point_of_interest;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import lombok.Getter;
@@ -30,7 +31,7 @@ import org.mcaccess.minecraftaccess.utils.events.ClientPlayingTick;
  */
 @Slf4j
 public class POIBlocks implements BalmClientModule {
-    private Config.POI.Blocks config;
+    private static final Config.POI.Blocks CONFIG = Config.getInstance().poi.blocks;
     private final Interval interval = Interval.defaultDelay();
     private @Nullable Block markedBlock = null;
 
@@ -39,7 +40,8 @@ public class POIBlocks implements BalmClientModule {
             new POIGroup.Sound(SoundEvents.ITEM_PICKUP, -5.0f),
             pos -> {
                 assert Minecraft.getInstance().level != null;
-                return Minecraft.getInstance().level.getBlockState(pos).is(markedBlock);
+                Block block = Minecraft.getInstance().level.getBlockState(pos).getBlock();
+                return markedBlock != null && Objects.equals(block, markedBlock);
             }
     );
 
@@ -69,7 +71,7 @@ public class POIBlocks implements BalmClientModule {
     private List<BlockPos> lastScanResults = new ArrayList<>();
 
     POIBlocks() {
-        loadConfig();
+        interval.setDelay(CONFIG.delay, Interval.Unit.MILLISECOND);
     }
 
     @Override
@@ -87,17 +89,23 @@ public class POIBlocks implements BalmClientModule {
     }
 
     private void tick(Minecraft client, Player player, Level level) {
-        setMarkedBlock(MainClass.poiManager.poiMarking.getMarkedBlock());
-        loadConfig();
+        Object currentMarkedObject = MainClass.poiManager.poiMarking.getMarkedObject().value;
+        if (currentMarkedObject instanceof Block block) {
+            markedBlock = block;
+        } else {
+            markedBlock = null;
+        }
 
-        if (!config.enabled) return;
+        interval.setDelay(CONFIG.delay, Interval.Unit.MILLISECOND);
+
+        if (!CONFIG.enabled) return;
         if (!interval.isReady()) return;
 
         if (client.screen != null) return; //Prevent running if any screen is opened
 
         log.trace("POIBlock started");
         scanBlocksAroundPlayer();
-        playerSoundAtFoundPOI(MainClass.poiManager.poiMarking.isMarked());
+        playerSoundAtFoundPOI(MainClass.poiManager.poiMarking.getMarkedObject().value != null);
         log.trace("POIBlock ended");
     }
 
@@ -123,33 +131,24 @@ public class POIBlocks implements BalmClientModule {
         BlockPos pos = Minecraft.getInstance().player.blockPosition();
         scanner.scanAndQualifyBlocksExposedInAirAround(pos.below(), 0);
         scanner.scanAndQualifyBlocksExposedInAirAround(pos.above(2), 0);
-        scanner.scanAndQualifyBlocksExposedInAirAround(pos, config.range);
-        scanner.scanAndQualifyBlocksExposedInAirAround(pos.above(), config.range);
+        scanner.scanAndQualifyBlocksExposedInAirAround(pos, CONFIG.range);
+        scanner.scanAndQualifyBlocksExposedInAirAround(pos.above(), CONFIG.range);
 
         lastScanResults = currentScanResults;
     }
 
     private void playerSoundAtFoundPOI(boolean isMarking) {
-        if (config.volume == 0.0f) return;
+        if (CONFIG.volume == 0.0f) return;
         if (isMarking && Config.getInstance().poi.marking.suppressOtherWhenEnabled) {
-            markedGroup.playSoundForGroupItems(BlockPos::getCenter, config.volume);
-        } else if (config.playSound) {
-            if (config.playSoundForOtherBlocks) {
+            markedGroup.playSoundForGroupItems(BlockPos::getCenter, CONFIG.volume);
+        } else if (CONFIG.playSound) {
+            if (CONFIG.playSoundForOtherBlocks) {
                 for (POIGroup<BlockPos> group : groups) {
-                    group.playSoundForGroupItems(BlockPos::getCenter, config.volume);
+                    group.playSoundForGroupItems(BlockPos::getCenter, CONFIG.volume);
                 }
             } else {
-                BuiltinBlockPOIGroups.ORE.group.playSoundForGroupItems(BlockPos::getCenter, config.volume);
+                BuiltinBlockPOIGroups.ORE.group.playSoundForGroupItems(BlockPos::getCenter, CONFIG.volume);
             }
         }
-    }
-
-    private void loadConfig() {
-        config = Config.getInstance().poi.blocks;
-        interval.setDelay(config.delay, Interval.Unit.MILLISECOND);
-    }
-
-    private void setMarkedBlock(@Nullable Block block) {
-        markedBlock = block;
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/POIEntities.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/POIEntities.java
@@ -3,7 +3,6 @@ package org.mcaccess.minecraftaccess.features.point_of_interest;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -33,15 +32,15 @@ import org.mcaccess.minecraftaccess.utils.events.ClientPlayingTick;
  */
 @Slf4j
 public class POIEntities implements BalmClientModule {
-    private Config.POI.Entities config;
+    private static final Config.POI.Entities CONFIG = Config.getInstance().poi.entities;
     private final Interval interval = Interval.defaultDelay();
 
-    private @Nullable Class<? extends Entity> marked = null;
+    private @Nullable Entity markedEntity = null;
 
     private final POIGroup<Entity> markedGroup = new POIGroup<>(
             "minecraft_access.point_of_interest.group.markedEntity",
             new POIGroup.Sound(SoundEvents.ITEM_PICKUP, -5.0f),
-            e -> marked != null && marked.isInstance(e)
+            e -> markedEntity != null && markedEntity.getClass().isInstance(e)
     );
 
     private final POIGroup<Entity> otherEntitiesGroup = new POIGroup<>(
@@ -57,7 +56,7 @@ public class POIEntities implements BalmClientModule {
     private List<Entity> lastScanResults = new ArrayList<>();
 
     POIEntities() {
-        loadConfig();
+        interval.setDelay(CONFIG.delay, Interval.Unit.MILLISECOND);
     }
 
     @Override
@@ -69,23 +68,29 @@ public class POIEntities implements BalmClientModule {
     public void initialize() {
         ClientPlayingTick.AFTER.register(this::tick);
         ClientLifecycleCallback.ConnectedToServer.EVENT.register(client -> {
-            marked = null;
+            markedEntity = null;
             lastScanResults = new ArrayList<>();
         });
     }
 
     private void tick(Minecraft client, Player player, Level level) {
-        setMarked(MainClass.poiManager.poiMarking.getMarkedEntity());
-        loadConfig();
+        Object currentMarkedObject = MainClass.poiManager.poiMarking.getMarkedObject().value;
+        if (currentMarkedObject instanceof Entity entity) {
+            markedEntity = entity;
+        } else {
+            markedEntity = null;
+        }
 
-        if (!config.enabled) return;
+        interval.setDelay(CONFIG.delay, Interval.Unit.MILLISECOND);
+
+        if (!CONFIG.enabled) return;
         if (!interval.isReady()) return;
 
         if (client.screen != null) return; //Prevent running if any screen is opened
 
         log.trace("POIEntities started");
         scanEntitiesAroundPlayer();
-        playerSoundAtFoundPOI(MainClass.poiManager.poiMarking.isMarked());
+        playerSoundAtFoundPOI(MainClass.poiManager.poiMarking.getMarkedObject().value != null);
         log.trace("POIEntities ended");
     }
 
@@ -98,7 +103,7 @@ public class POIEntities implements BalmClientModule {
 
         LocalPlayer player = Minecraft.getInstance().player;
         assert player != null;
-        AABB scanBox = player.getBoundingBox().inflate(config.range, config.range, config.range);
+        AABB scanBox = player.getBoundingBox().inflate(CONFIG.range, CONFIG.range, CONFIG.range);
         assert Minecraft.getInstance().level != null;
         List<Entity> entities = Minecraft.getInstance().level.getEntities(player, scanBox);
 
@@ -115,26 +120,14 @@ public class POIEntities implements BalmClientModule {
     }
 
     private void playerSoundAtFoundPOI(boolean isMarking) {
-        if (config.volume == 0.0f) return;
+        if (CONFIG.volume == 0.0f) return;
         Function<Entity, Vec3> mapper = e -> e.blockPosition().getCenter();
         if (isMarking && Config.getInstance().poi.marking.suppressOtherWhenEnabled) {
-            markedGroup.playSoundForGroupItems(mapper, config.volume);
-        } else if (config.playSound) {
+            markedGroup.playSoundForGroupItems(mapper, CONFIG.volume);
+        } else if (CONFIG.playSound) {
             for (POIGroup<Entity> group : groups) {
-                group.playSoundForGroupItems(mapper, config.volume);
+                group.playSoundForGroupItems(mapper, CONFIG.volume);
             }
         }
-    }
-
-    /**
-     * Loads the configs from config.json.
-     */
-    private void loadConfig() {
-        config = Config.getInstance().poi.entities;
-        interval.setDelay(config.delay, Interval.Unit.MILLISECOND);
-    }
-
-    private void setMarked(@Nullable Entity entity) {
-        marked = Optional.ofNullable(entity).map(Entity::getClass).orElse(null);
     }
 }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/POIMarking.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/POIMarking.java
@@ -2,38 +2,27 @@ package org.mcaccess.minecraftaccess.features.point_of_interest;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import lombok.Getter;
-import net.blay09.mods.balm.client.platform.event.callback.ClientLifecycleCallback;
 import net.blay09.mods.balm.client.platform.module.BalmClientModule;
 import net.blay09.mods.kuma.api.InputBinding;
 import net.blay09.mods.kuma.api.KeyModifier;
 import net.blay09.mods.kuma.api.KeyModifiers;
 import net.blay09.mods.kuma.api.Kuma;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.EntityHitResult;
-import net.minecraft.world.phys.HitResult;
 import org.jetbrains.annotations.NotNull;
 
 import org.mcaccess.minecraftaccess.Config;
 import org.mcaccess.minecraftaccess.MainClass;
 import org.mcaccess.minecraftaccess.api.WorldNarrator;
 import org.mcaccess.minecraftaccess.utils.KeyMappingCategories;
+import org.mcaccess.minecraftaccess.utils.events.ServerLocal;
 
 public class POIMarking implements BalmClientModule {
     @Getter
-    private boolean isMarked = false;
-
-    @Getter
-    private Entity markedEntity = null;
-
-    @Getter
-    private Block markedBlock = null;
+    private final ServerLocal<Object> markedObject = new ServerLocal<>(() -> null);
 
     @Override
     public @NotNull Identifier getId() {
@@ -42,12 +31,6 @@ public class POIMarking implements BalmClientModule {
 
     @Override
     public void initialize() {
-        ClientLifecycleCallback.ConnectedToServer.EVENT.register(client -> {
-            isMarked = false;
-            markedEntity = null;
-            markedBlock = null;
-        });
-
         Kuma.createKeyMapping(Identifier.fromNamespaceAndPath(MainClass.MOD_ID, "other.poi_marking/mark"))
                 .withDefault(InputBinding.key(InputConstants.KEY_Y, KeyModifiers.of(KeyModifier.CONTROL)))
                 .overrideCategory(KeyMappingCategories.OTHER)
@@ -68,42 +51,29 @@ public class POIMarking implements BalmClientModule {
     }
 
     private void mark() {
-        if (isMarked) return;
+        if (markedObject.value != null) return;
 
-        Minecraft client = Minecraft.getInstance();
-        HitResult hit = client.hitResult;
-        if (hit == null) return;
+        Object currentObject = MainClass.poiManager.objectTracker.getCurrentObject();
+        if (currentObject == null) return;
 
-        switch (hit.getType()) {
-            case MISS -> {
-                return;
-            }
-            case BLOCK -> {
-                ClientLevel world = client.level;
-                if (world == null) return;
-                BlockPos pos = ((BlockHitResult) hit).getBlockPos();
-                markedBlock = world.getBlockState(pos).getBlock();
-
-                String name = MainClass.registry(WorldNarrator.class).get(Config.getInstance().narrateCrosshair.narrator).narrate(pos);
-                MainClass.narrate(I18n.get("minecraft_access.point_of_interest.marking.marked", name), true);
-            }
-            case ENTITY -> {
-                Entity entity = ((EntityHitResult) hit).getEntity();
-                markedEntity = entity;
-
-                String name = MainClass.registry(WorldNarrator.class).get(Config.getInstance().narrateCrosshair.narrator).narrate(entity);
-                MainClass.narrate(I18n.get("minecraft_access.point_of_interest.marking.marked", name), true);
-            }
+        String name;
+        if (currentObject instanceof BlockPos pos) {
+            assert Minecraft.getInstance().level != null;
+            markedObject.value = Minecraft.getInstance().level.getBlockState(pos).getBlock();
+            name = MainClass.registry(WorldNarrator.class).get(Config.getInstance().narrateCrosshair.narrator).narrate(pos);
+        } else if (currentObject instanceof Entity entity) {
+            markedObject.value = entity;
+            name = MainClass.registry(WorldNarrator.class).get(Config.getInstance().narrateCrosshair.narrator).narrate(entity);
+        } else {
+            return;
         }
 
-        isMarked = true;
+        MainClass.narrate(I18n.get("minecraft_access.point_of_interest.marking.marked", name), true);
     }
 
     private void unmark() {
-        if (!isMarked) return;
-        markedBlock = null;
-        markedEntity = null;
-        isMarked = false;
+        if (markedObject.value == null) return;
+        markedObject.value = null;
         MainClass.narrate(I18n.get("minecraft_access.point_of_interest.marking.unmarked"), true);
     }
 }


### PR DESCRIPTION
# Changelog
## Feature Updates
- POI Marking now finds what to mark based on the current object tracker object at the point of marking instead of the current thing the player is looking at