### PR TITLE
Make narration hints and crouch&sprint sounds configurable

### DIFF
--- a/common/src/main/java/org/mcaccess/minecraftaccess/Config.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/Config.java
@@ -96,7 +96,7 @@ public final class Config implements ConfigData {
 
     public static final class SpeechSettings {
         public float speechRate = 50;
-        public boolean speakHints = true;
+        public boolean narrateHints = true;
 
         private SpeechSettings() {
         }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/Config.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/Config.java
@@ -78,6 +78,7 @@ public final class Config implements ConfigData {
         public boolean timeIndicatorEnabled = true;
         public boolean xpIndicatorEnabled = true;
         public boolean facingDirectionEnabled = true;
+        public boolean crouchAndSprintCues = true;
         @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.BUTTON)
         public PickedUpItemNarration pickedUpItemNarration = PickedUpItemNarration.WHEN_FISHING;
         public boolean narrateHeldItemsCountWhenChanged = true;

--- a/common/src/main/java/org/mcaccess/minecraftaccess/Config.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/Config.java
@@ -95,6 +95,7 @@ public final class Config implements ConfigData {
 
     public static final class SpeechSettings {
         public float speechRate = 50;
+        public boolean speakHints = true;
 
         private SpeechSettings() {
         }

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/PlayerStatus.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/PlayerStatus.java
@@ -89,7 +89,7 @@ public class PlayerStatus implements BalmClientModule {
                 (client, player, level) -> player.isSprinting() && !player.isCrouching(),
                 (client, player, level, previous, value) -> {
                     if (Config.getInstance().features.crouchAndSprintCues) {
-                        level.playPlayerSound(SoundEvents.SHOVEL_FLATTEN, SoundSource.PLAYERS, 1.0f, value ? 2.5f : 0.9f)
+                        level.playPlayerSound(SoundEvents.SHOVEL_FLATTEN, SoundSource.PLAYERS, 1.0f, value ? 2.5f : 0.9f);
                     }
                 }
         );

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/PlayerStatus.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/PlayerStatus.java
@@ -86,8 +86,12 @@ public class PlayerStatus implements BalmClientModule {
         );
 
         new ServerChangeDetector<Boolean>().levelEvent(
-                (client, player, level) -> Config.getInstance().features.crouchAndSprintCues && player.isSprinting() && !player.isCrouching(),
-                (client, player, level, previous, value) -> level.playPlayerSound(SoundEvents.SHOVEL_FLATTEN, SoundSource.PLAYERS, 1.0f, value ? 2.5f : 0.9f)
+                (client, player, level) -> player.isSprinting() && !player.isCrouching(),
+                (client, player, level, previous, value) -> {
+                    if (Config.getInstance().features.crouchAndSprintCues) {
+                        level.playPlayerSound(SoundEvents.SHOVEL_FLATTEN, SoundSource.PLAYERS, 1.0f, value ? 2.5f : 0.9f)
+                    }
+                }
         );
 
         for (Map.Entry<Identifier, Status> entry : MainClass.registry(Status.class).entrySet()) {

--- a/common/src/main/java/org/mcaccess/minecraftaccess/features/PlayerStatus.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/features/PlayerStatus.java
@@ -78,7 +78,7 @@ public class PlayerStatus implements BalmClientModule {
         new ServerChangeDetector<Boolean>().levelEvent(
                 (client, player, level) -> player.isCrouching(),
                 (client, player, level, previous, value) -> {
-                    if (!value && player.isSprinting()) {
+                    if (!Config.getInstance().features.crouchAndSprintCues || !value && player.isSprinting()) {
                         return;
                     }
                     level.playPlayerSound(SoundEvents.SHOVEL_FLATTEN, SoundSource.PLAYERS, 1.0f, value ? 0.5f : 0.9f);
@@ -86,7 +86,7 @@ public class PlayerStatus implements BalmClientModule {
         );
 
         new ServerChangeDetector<Boolean>().levelEvent(
-                (client, player, level) -> player.isSprinting() && !player.isCrouching(),
+                (client, player, level) -> Config.getInstance().features.crouchAndSprintCues && player.isSprinting() && !player.isCrouching(),
                 (client, player, level, previous, value) -> level.playPlayerSound(SoundEvents.SHOVEL_FLATTEN, SoundSource.PLAYERS, 1.0f, value ? 2.5f : 0.9f)
         );
 

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/NarrationElementOutputMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/NarrationElementOutputMixin.java
@@ -18,7 +18,7 @@ import org.mcaccess.minecraftaccess.Config;
 abstract class NarrationElementOutputMixin {
     @Inject(method = "add", at = @At("HEAD"), cancellable = true)
     private void removePositionAndUsageNarrations(NarratedElementType type, NarrationThunk<?> contents, CallbackInfo ci) {
-        if (Config.getInstance().speechSettings.speakHints) {
+        if (Config.getInstance().speechSettings.narrateHints) {
             return;
         }
 

--- a/common/src/main/java/org/mcaccess/minecraftaccess/mixin/NarrationElementOutputMixin.java
+++ b/common/src/main/java/org/mcaccess/minecraftaccess/mixin/NarrationElementOutputMixin.java
@@ -9,6 +9,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import org.mcaccess.minecraftaccess.Config;
+
 /**
  * The {@link ScreenNarrationCollector.Output} class is the only one implementation of {@link NarrationElementOutput}.
  */
@@ -16,6 +18,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 abstract class NarrationElementOutputMixin {
     @Inject(method = "add", at = @At("HEAD"), cancellable = true)
     private void removePositionAndUsageNarrations(NarratedElementType type, NarrationThunk<?> contents, CallbackInfo ci) {
+        if (Config.getInstance().speechSettings.speakHints) {
+            return;
+        }
+
         switch (type) {
             case TITLE:
             case HINT:

--- a/common/src/main/resources/assets/minecraft_access/lang/en_us.json
+++ b/common/src/main/resources/assets/minecraft_access/lang/en_us.json
@@ -441,7 +441,7 @@
     "text.autoconfig.minecraft-access.option.poi.marking": "Marking",
     "text.autoconfig.minecraft-access.option.poi.marking.suppressOtherWhenEnabled": "Suppress other POI while marking",
     "text.autoconfig.minecraft-access.option.poi.narrateDistance": "Narrate relative distance to target",
-    "text.autoconfig.minecraft-access.option.speechSettings.speakHints": "Speak hints",
+    "text.autoconfig.minecraft-access.option.speechSettings.narrateHints": "Narrate hints",
     "text.autoconfig.minecraft-access.option.speechSettings.speechRate": "Speech rate (MacOS)",
     "text.autoconfig.minecraft-access.option.use12HourTimeFormat": "Use 12-hour time format",
     "text.autoconfig.minecraft-access.title": "Minecraft Access Settings"

--- a/common/src/main/resources/assets/minecraft_access/lang/en_us.json
+++ b/common/src/main/resources/assets/minecraft_access/lang/en_us.json
@@ -440,6 +440,7 @@
     "text.autoconfig.minecraft-access.option.poi.marking": "Marking",
     "text.autoconfig.minecraft-access.option.poi.marking.suppressOtherWhenEnabled": "Suppress other POI while marking",
     "text.autoconfig.minecraft-access.option.poi.narrateDistance": "Narrate relative distance to target",
+    "text.autoconfig.minecraft-access.option.speechSettings.speechRate": "Speak hints",
     "text.autoconfig.minecraft-access.option.speechSettings.speechRate": "Speech rate (MacOS)",
     "text.autoconfig.minecraft-access.option.use12HourTimeFormat": "Use 12-hour time format",
     "text.autoconfig.minecraft-access.title": "Minecraft Access Settings"

--- a/common/src/main/resources/assets/minecraft_access/lang/en_us.json
+++ b/common/src/main/resources/assets/minecraft_access/lang/en_us.json
@@ -374,6 +374,7 @@
     "text.autoconfig.minecraft-access.option.features.actionBarEnabled": "Narrate action bar messages",
     "text.autoconfig.minecraft-access.option.features.alwaysNarrateDimensionInBiomeIndicator": "Always narrate dimension name in Biome Indicator",
     "text.autoconfig.minecraft-access.option.features.biomeIndicatorEnabled": "Enable biome indicator",
+    "text.autoconfig.minecraft-access.option.features.crouchAndSprintCues": "Play crouch and sprint sound cues",
     "text.autoconfig.minecraft-access.option.features.facingDirectionEnabled": "Enable facing direction narration",
     "text.autoconfig.minecraft-access.option.features.narrateHeldItemsCountWhenChanged": "Narrate held items count when changed",
     "text.autoconfig.minecraft-access.option.features.onlyNarrateActionBarUpdates": "Only narrate the changed part of the action bar",
@@ -440,7 +441,7 @@
     "text.autoconfig.minecraft-access.option.poi.marking": "Marking",
     "text.autoconfig.minecraft-access.option.poi.marking.suppressOtherWhenEnabled": "Suppress other POI while marking",
     "text.autoconfig.minecraft-access.option.poi.narrateDistance": "Narrate relative distance to target",
-    "text.autoconfig.minecraft-access.option.speechSettings.speechRate": "Speak hints",
+    "text.autoconfig.minecraft-access.option.speechSettings.speakHints": "Speak hints",
     "text.autoconfig.minecraft-access.option.speechSettings.speechRate": "Speech rate (MacOS)",
     "text.autoconfig.minecraft-access.option.use12HourTimeFormat": "Use 12-hour time format",
     "text.autoconfig.minecraft-access.title": "Minecraft Access Settings"


### PR DESCRIPTION
# Changelog

## New Features
- Added config for narrating the built in Minecraft narration hints involving interaction and positional hints (defaulted to enabled)

## Feature Updates
- Added config for the playing of the crouch and sprint sounds previously added (defaulted to enabled)