### PR TITLE
Fix object tracker not working in fluids

### DIFF
--- a/docs/static/api/client/javadoc
+++ b/docs/static/api/client/javadoc
@@ -1,1 +1,1 @@
-../../../../common/build/docs/javadoc/
+../../../../build/docs/javadoc/

--- a/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/BlockScanner.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/features/point_of_interest/BlockScanner.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
 
 /**
  * @implNote uses DFS algorithm
@@ -20,8 +21,7 @@ public class BlockScanner {
 
     /**
      * Scan blocks around given center position and apply consumer to them.
-     * Note that the "scan wave" won't "penetrate" through non-air blocks,
-     * image blow up a balloon in a bottle, the balloon will fit the shape of the bottle.
+     * Note that the "scan wave" won't penetrate through non-air blocks or fluid blocks if the player isn't in a liquid
      *
      * @param blockPos center position
      * @param range    range
@@ -32,7 +32,10 @@ public class BlockScanner {
 
         int nextStepRange = range - 1;
         assert Minecraft.getInstance().level != null;
-        if (Minecraft.getInstance().level.getBlockState(blockPos).isAir() && nextStepRange >= 0) {
+        BlockState currentBlockState = Minecraft.getInstance().level.getBlockState(blockPos);
+        if ((currentBlockState.isAir()
+                || !currentBlockState.getFluidState().isEmpty() && Minecraft.getInstance().player.isInLiquid())
+                && nextStepRange >= 0) {
             scanAndQualifyBlocksExposedInAirAround(blockPos.north(), nextStepRange);
             scanAndQualifyBlocksExposedInAirAround(blockPos.south(), nextStepRange);
             scanAndQualifyBlocksExposedInAirAround(blockPos.west(), nextStepRange);


### PR DESCRIPTION
# Changelog

## Feature Updates
- The object tracker now recognizes POIs surrounded by fluid if the player is themselves also in the fluid