### PR TITLE
Mixin Consistency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ compileJava {
     options.release = 25
 }
 
-jar.enabled false
+jar.enabled = false
 shadowJar {
     archiveClassifier = null
     configurations = [project.configurations.shadow]

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/AnvilScreenMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/AnvilScreenMixin.java
@@ -23,7 +23,7 @@ abstract class AnvilScreenMixin {
      * Let the original logic build the text, we don't want to repeat that.
      */
     @Inject(method = "extractLabels", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphicsExtractor;fill(IIIII)V"))
-    private void narrateCost(GuiGraphicsExtractor context, int mouseX, int mouseY, CallbackInfo ci, @Local Component line) {
+    private void narrateCost(GuiGraphicsExtractor graphics, int xm, int ym, CallbackInfo ci, @Local Component line) {
         if (line instanceof Component component) {
             String lineString = component.getString();
             if (!lineString.equals(previousLine)) {
@@ -34,7 +34,7 @@ abstract class AnvilScreenMixin {
     }
 
     @Inject(method = "extractLabels", at = @At("RETURN"))
-    private void resetWhenCostDisappears(GuiGraphicsExtractor context, int mouseX, int mouseY, CallbackInfo ci, @Local(ordinal = 2) int cost) {
+    private void resetWhenCostDisappears(GuiGraphicsExtractor graphics, int xm, int ym, CallbackInfo ci, @Local(ordinal = 2) int cost) {
         if (cost <= 0) {
             previousLine = null;
         }

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/BookViewScreenMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/BookViewScreenMixin.java
@@ -15,10 +15,11 @@ import org.mcaccess.minecraftaccess.MainClass;
 abstract class BookViewScreenMixin {
     @Shadow
     private int currentPage;
+
     @Shadow
     private BookViewScreen.BookAccess bookAccess;
 
-    @Inject(at = @At("HEAD"), method = "keyPressed")
+    @Inject(method = "keyPressed", at = @At("HEAD"))
     private void repeatPageContents(KeyEvent event, CallbackInfoReturnable<Boolean> cir) {
         if (event.key() == InputConstants.KEY_R) {
             MainClass.narrate(bookAccess.getPage(currentPage).getString(), true);

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/ButtonMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/ButtonMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Button.class)
 abstract class ButtonMixin {
-    @Inject(at = @At("HEAD"), method = "updateWidgetNarration", cancellable = true) // From 1.19.3
+    @Inject(method = "updateWidgetNarration", at = @At("HEAD"), cancellable = true)
     private void appendNarrations(CallbackInfo ci) {
         if (Minecraft.getInstance().screen instanceof MerchantScreen) ci.cancel();
     }

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/ButtonMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/ButtonMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(Button.class)
 abstract class ButtonMixin {
     @Inject(at = @At("HEAD"), method = "updateWidgetNarration", cancellable = true) // From 1.19.3
-    private void appendNarrations(CallbackInfo callbackInfo) {
-        if (Minecraft.getInstance().screen instanceof MerchantScreen) callbackInfo.cancel();
+    private void appendNarrations(CallbackInfo ci) {
+        if (Minecraft.getInstance().screen instanceof MerchantScreen) ci.cancel();
     }
 }

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
@@ -29,30 +29,6 @@ abstract class ChatScreenMixin {
     @Shadow
     protected EditBox input;
 
-    @Inject(method = "init", at = @At("HEAD"))
-    private void init(CallbackInfo ci) {
-        currentChatMessagePage = 0;
-    }
-
-    @Redirect(method = "updateNarrationState", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/EditBox;getValue()Ljava/lang/String;"))
-    private String suppressContent(EditBox instance) {
-        return "";
-    }
-
-    /**
-     * Add custom keystroke handling for chat screen.
-     */
-    @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
-    private void keyPressed(KeyEvent event, CallbackInfoReturnable<Boolean> cir) {
-        if (!repeatPreviousChatMessage(event.key())) return;
-
-        // Method executes to here means one of custom keystroke handling above is triggered,
-        // so we want to cancel the logic in injected original method,
-        // since its logic is also return after one handling triggered.
-        cir.setReturnValue(true);
-        cir.cancel();
-    }
-
     /**
      * This method checks if the key code corresponds to a numeric key or numeric keypad key between 0 and 9,
      * while Alt key is pressed too.
@@ -117,6 +93,30 @@ abstract class ChatScreenMixin {
         if ((messages.size() - indexOffset) <= 0) return;
 
         MainClass.narrate(messages.get(indexOffset).content().getString(), true);
+    }
+
+    @Inject(method = "init", at = @At("HEAD"))
+    private void init(CallbackInfo ci) {
+        currentChatMessagePage = 0;
+    }
+
+    @Redirect(method = "updateNarrationState", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/EditBox;getValue()Ljava/lang/String;"))
+    private String suppressContent(EditBox instance) {
+        return "";
+    }
+
+    /**
+     * Add custom keystroke handling for chat screen.
+     */
+    @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
+    private void keyPressed(KeyEvent event, CallbackInfoReturnable<Boolean> cir) {
+        if (!repeatPreviousChatMessage(event.key())) return;
+
+        // Method executes to here means one of custom keystroke handling above is triggered,
+        // so we want to cancel the logic in injected original method,
+        // since its logic is also return after one handling triggered.
+        cir.setReturnValue(true);
+        cir.cancel();
     }
 
     // Since there is no text modifying narration, we want to manually narrate when the chat history is switched.

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/ChatScreenMixin.java
@@ -29,12 +29,12 @@ abstract class ChatScreenMixin {
     @Shadow
     protected EditBox input;
 
-    @Inject(at = @At("HEAD"), method = "init")
+    @Inject(method = "init", at = @At("HEAD"))
     private void init(CallbackInfo ci) {
         currentChatMessagePage = 0;
     }
 
-    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/EditBox;getValue()Ljava/lang/String;"), method = "updateNarrationState")
+    @Redirect(method = "updateNarrationState", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/EditBox;getValue()Ljava/lang/String;"))
     private String suppressContent(EditBox instance) {
         return "";
     }
@@ -42,7 +42,7 @@ abstract class ChatScreenMixin {
     /**
      * Add custom keystroke handling for chat screen.
      */
-    @Inject(at = @At("HEAD"), method = "keyPressed", cancellable = true)
+    @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
     private void keyPressed(KeyEvent event, CallbackInfoReturnable<Boolean> cir) {
         if (!repeatPreviousChatMessage(event.key())) return;
 
@@ -120,7 +120,7 @@ abstract class ChatScreenMixin {
     }
 
     // Since there is no text modifying narration, we want to manually narrate when the chat history is switched.
-    @Inject(at = @At("TAIL"), method = "moveInHistory")
+    @Inject(method = "moveInHistory", at = @At("TAIL"))
     private void narrateSwitchedChatHistory(CallbackInfo ci) {
         MainClass.narrate(input.getValue(), true);
     }

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/CheckboxMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/CheckboxMixin.java
@@ -25,11 +25,11 @@ abstract class CheckboxMixin extends AbstractWidget {
      */
     @Override
     @Overwrite
-    public void updateWidgetNarration(NarrationElementOutput builder) {
+    public void updateWidgetNarration(NarrationElementOutput output) {
         if (selected) {
-            builder.add(NarratedElementType.TITLE, Component.translatable("minecraft_access.gui.checkbox_checked", getMessage()));
+            output.add(NarratedElementType.TITLE, Component.translatable("minecraft_access.gui.checkbox_checked", getMessage()));
         } else {
-            builder.add(NarratedElementType.TITLE, Component.translatable("minecraft_access.gui.checkbox_unchecked", getMessage()));
+            output.add(NarratedElementType.TITLE, Component.translatable("minecraft_access.gui.checkbox_unchecked", getMessage()));
         }
     }
 }

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/ClientPacketListenerMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/ClientPacketListenerMixin.java
@@ -28,7 +28,7 @@ abstract class ClientPacketListenerMixin implements TickablePacketListener, Clie
     @Shadow
     private ClientLevel level;
 
-    @Inject(at = @At("HEAD"), method = "handleTakeItemEntity")
+    @Inject(method = "handleTakeItemEntity", at = @At("HEAD"))
     private void handleTakeItemEntity(ClientboundTakeItemEntityPacket packet, CallbackInfo ci) {
         Minecraft client = Minecraft.getInstance();
         LocalPlayer player = client.player;

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/EditBoxMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/EditBoxMixin.java
@@ -28,10 +28,13 @@ import org.mcaccess.minecraftaccess.MainClass;
 abstract class EditBoxMixin extends AbstractWidget {
     @Shadow
     private String value;
+
     @Shadow
     private int cursorPos;
+
     @Shadow
     private int highlightPos;
+
     @Shadow
     private @Nullable String suggestion;
 
@@ -63,7 +66,7 @@ abstract class EditBoxMixin extends AbstractWidget {
      * Prevents any character input if alt is held down.
      * This logic is for "alt + num key to repeat chat message" function in {@link ChatScreenMixin}
      */
-    @Inject(at = @At("HEAD"), method = "charTyped", cancellable = true)
+    @Inject(method = "charTyped", at = @At("HEAD"), cancellable = true)
     private void charTyped(CallbackInfoReturnable<Boolean> cir) {
         if (!Minecraft.getInstance().hasAltDown()) return;
 
@@ -71,7 +74,7 @@ abstract class EditBoxMixin extends AbstractWidget {
         cir.cancel();
     }
 
-    @Inject(at = @At("HEAD"), method = "keyPressed")
+    @Inject(method = "keyPressed", at = @At("HEAD"))
     private void narrateCursorHoverOverText(KeyEvent event, CallbackInfoReturnable<Boolean> cir) {
         if (!canConsumeInput()) {
             return;
@@ -113,7 +116,7 @@ abstract class EditBoxMixin extends AbstractWidget {
         }
     }
 
-    @Inject(at = @At("RETURN"), method = "keyPressed")
+    @Inject(method = "keyPressed", at = @At("RETURN"))
     private void narrateSelectedText(CallbackInfoReturnable<Boolean> cir) {
         if (!canConsumeInput()) {
             return;
@@ -124,7 +127,7 @@ abstract class EditBoxMixin extends AbstractWidget {
         }
     }
 
-    @Inject(at = @At("HEAD"), method = "deleteChars")
+    @Inject(method = "deleteChars", at = @At("HEAD"))
     private void narrateErasedText(int dir, CallbackInfo ci) {
         int cursorPos = getCursorPos(dir);
         // select all text (ctrl+a) will not change the cursor position,

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/EditBoxMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/EditBoxMixin.java
@@ -125,8 +125,8 @@ abstract class EditBoxMixin extends AbstractWidget {
     }
 
     @Inject(at = @At("HEAD"), method = "deleteChars")
-    private void narrateErasedText(int characterOffset, CallbackInfo ci) {
-        int cursorPos = getCursorPos(characterOffset);
+    private void narrateErasedText(int dir, CallbackInfo ci) {
+        int cursorPos = getCursorPos(dir);
         // select all text (ctrl+a) will not change the cursor position,
         // if we delete all text then, the erasedText will be a wrong value (one char ahead of cursor)
         // don't narrate under this condition

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/EyeOfEnderMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/EyeOfEnderMixin.java
@@ -25,12 +25,12 @@ abstract class EyeOfEnderMixin extends Entity implements ItemSupplier {
     @Shadow
     private int life;
 
-    protected EyeOfEnderMixin(EntityType<?> type, Level world) {
-        super(type, world);
+    protected EyeOfEnderMixin(EntityType<? extends EyeOfEnder> type, Level level) {
+        super(type, level);
     }
 
-    @Inject(at = @At("HEAD"), method = "tick")
-    private void tick(CallbackInfo callbackInfo) {
+    @Inject(method = "tick", at = @At("HEAD"))
+    private void tick(CallbackInfo ci) {
         if (life != 1) return;
         if (!Config.getInstance().poi.locking.autoLockEyeOfEnderEntity) {
             return;

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/GameModeSwitcherScreenMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/GameModeSwitcherScreenMixin.java
@@ -19,12 +19,12 @@ abstract class GameModeSwitcherScreenMixin {
     private GameModeIconAccessor previous;
 
     @WrapOperation(
+            method = {"init", "keyPressed", "render"},
             at = @At(
                     value = "FIELD",
                     target = "Lnet/minecraft/client/gui/screens/debug/GameModeSwitcherScreen;currentlyHovered:Lnet/minecraft/client/gui/screens/debug/GameModeSwitcherScreen$GameModeIcon;",
                     opcode = Opcodes.PUTFIELD
-            ),
-            method = {"init", "keyPressed", "render"}
+            )
     )
     private void narrateGameMode(GameModeSwitcherScreen instance, @Coerce GameModeIconAccessor value, Operation<Void> original) {
         original.call(instance, value);

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorMixin.java
@@ -18,7 +18,7 @@ abstract class GameNarratorMixin {
         return new NarratorDummy();
     }
 
-    @Inject(at = @At("HEAD"), method = "narrateMessage", cancellable = true)
+    @Inject(method = "narrateMessage", at = @At("HEAD"), cancellable = true)
     private void narrateMessage(String message, boolean interrupt, CallbackInfo ci) {
         if (MainClass.getScreenReader() == null || !MainClass.getScreenReader().isInitialized()) {
             return;

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/GameNarratorMixin.java
@@ -19,11 +19,11 @@ abstract class GameNarratorMixin {
     }
 
     @Inject(at = @At("HEAD"), method = "narrateMessage", cancellable = true)
-    private void narrateMessage(String text, boolean interrupt, CallbackInfo callbackInfo) {
+    private void narrateMessage(String message, boolean interrupt, CallbackInfo ci) {
         if (MainClass.getScreenReader() == null || !MainClass.getScreenReader().isInitialized()) {
             return;
         }
-        MainClass.getScreenReader().narrate(text, interrupt);
-        callbackInfo.cancel();
+        MainClass.getScreenReader().narrate(message, interrupt);
+        ci.cancel();
     }
 }

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiGraphicsExtractorMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiGraphicsExtractorMixin.java
@@ -26,7 +26,8 @@ abstract class GuiGraphicsExtractorMixin {
     private static String previous;
 
     @Inject(method = "setTooltipForNextFrameInternal", at = @At("HEAD"))
-    private void narrateTooltip(Font font, List<ClientTooltipComponent> lines, int xo, int yo, ClientTooltipPositioner positioner, @Nullable Identifier style, boolean replaceExisting, CallbackInfo ci) {
+    private void narrateTooltip(Font font, List<ClientTooltipComponent> lines, int xo, int yo, ClientTooltipPositioner positioner, @Nullable Identifier style,
+                                boolean replaceExisting, CallbackInfo ci) {
         if (Config.getInstance().inventoryControls.enabled) {
             return;
         }

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiGraphicsExtractorMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiGraphicsExtractorMixin.java
@@ -26,11 +26,11 @@ abstract class GuiGraphicsExtractorMixin {
     private static String previous;
 
     @Inject(at = @At("HEAD"), method = "setTooltipForNextFrameInternal")
-    private void narrateTooltip(Font font, List<ClientTooltipComponent> list, int i, int j, ClientTooltipPositioner clientTooltipPositioner, @Nullable Identifier identifier, boolean bl, CallbackInfo ci) {
+    private void narrateTooltip(Font font, List<ClientTooltipComponent> lines, int xo, int yo, ClientTooltipPositioner positioner, @Nullable Identifier style, boolean replaceExisting, CallbackInfo ci) {
         if (Config.getInstance().inventoryControls.enabled) {
             return;
         }
-        String combined = list.stream()
+        String combined = lines.stream()
                 .flatMap(component -> component instanceof ClientTextTooltipAccessor text ? Stream.of(text) : Stream.empty())
                 .map(ClientTextTooltipAccessor::getText)
                 .map(NarrationUtils::formattedCharSequenceToString)

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiGraphicsExtractorMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiGraphicsExtractorMixin.java
@@ -25,7 +25,7 @@ abstract class GuiGraphicsExtractorMixin {
     @Unique
     private static String previous;
 
-    @Inject(at = @At("HEAD"), method = "setTooltipForNextFrameInternal")
+    @Inject(method = "setTooltipForNextFrameInternal", at = @At("HEAD"))
     private void narrateTooltip(Font font, List<ClientTooltipComponent> lines, int xo, int yo, ClientTooltipPositioner positioner, @Nullable Identifier style, boolean replaceExisting, CallbackInfo ci) {
         if (Config.getInstance().inventoryControls.enabled) {
             return;

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
@@ -30,7 +30,7 @@ abstract class GuiMixin {
     @Unique
     private String previousActionBarContent = "";
 
-    @Inject(at = @At("HEAD"), method = "setOverlayMessage(Lnet/minecraft/network/chat/Component;Z)V")
+    @Inject(method = "setOverlayMessage(Lnet/minecraft/network/chat/Component;Z)V", at = @At("HEAD"))
     private void narrateActionbar(Component string, boolean animate, CallbackInfo ci) {
         Config config = Config.getInstance();
         if (config.features.actionBarEnabled) {

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/GuiMixin.java
@@ -31,10 +31,10 @@ abstract class GuiMixin {
     private String previousActionBarContent = "";
 
     @Inject(at = @At("HEAD"), method = "setOverlayMessage(Lnet/minecraft/network/chat/Component;Z)V")
-    private void narrateActionbar(Component message, boolean tinted, CallbackInfo ci) {
+    private void narrateActionbar(Component string, boolean animate, CallbackInfo ci) {
         Config config = Config.getInstance();
         if (config.features.actionBarEnabled) {
-            String msg = message.getString();
+            String msg = string.getString();
             boolean contentChanged = !previousActionBarContent.equals(msg);
             if (contentChanged) {
                 if (config.features.onlyNarrateActionBarUpdates) {

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/I18nMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/I18nMixin.java
@@ -22,7 +22,7 @@ abstract class I18nMixin {
      * when translation key has "{}".
      */
     @SuppressWarnings("unchecked")
-    @Inject(at = @At("HEAD"), method = "get", cancellable = true)
+    @Inject(method = "get", at = @At("HEAD"), cancellable = true)
     private static void useNamedFormatter(String key, Object[] args, CallbackInfoReturnable<String> cir) {
         if (args.length == 1 && args[0] instanceof Map) {
             Map<String, Object> params = (Map<String, Object>) args[0];

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/InputMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/InputMixin.java
@@ -25,12 +25,12 @@ abstract class InputMixin {
                     target = "Lnet/minecraft/client/gui/narration/NarrationElementOutput;add(Lnet/minecraft/client/gui/narration/NarratedElementType;Lnet/minecraft/network/chat/Component;)V"
             )
     )
-    private void setDeduplication(NarrationElementOutput instance, NarratedElementType type, Component contents) {
+    private void setDeduplication(NarrationElementOutput output, NarratedElementType type, Component contents) {
         NarrationThunk<?> thunk = NarrationThunk.from(contents);
         ((NarrationThunkExt) thunk).setDeduplication(switch (Minecraft.getInstance().screen) {
             case BookEditScreenAccessor bookEditScreen -> bookEditScreen.getCurrentPage();
             case null, default -> this;
         });
-        instance.add(type, thunk);
+        output.add(type, thunk);
     }
 }

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/ItemStackMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/ItemStackMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = ItemStack.class, priority = 0)
 abstract class ItemStackMixin {
-    @Inject(at = @At("RETURN"), method = "getTooltipLines")
+    @Inject(method = "getTooltipLines", at = @At("RETURN"))
     private void getTooltipLinesMixin(CallbackInfoReturnable<List<Component>> info) {
         if (Minecraft.getInstance().level == null) return;
         List<Component> list = info.getReturnValue();

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/LivingEntityMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/LivingEntityMixin.java
@@ -22,19 +22,19 @@ import org.mcaccess.minecraftaccess.utils.NarrationUtils;
 @Mixin(LivingEntity.class)
 abstract class LivingEntityMixin {
     @Inject(method = "onEffectUpdated", at = @At("TAIL"))
-    private void narrateEffectApplication(MobEffectInstance effectInstance, boolean forced, Entity entity, CallbackInfo ci) {
+    private void narrateEffectApplication(MobEffectInstance effect, boolean doRefreshAttributes, Entity source, CallbackInfo ci) {
         if (Objects.equals(Minecraft.getInstance().player, this)) {
-            if (Minecraft.getInstance().player.hasEffect(effectInstance.getEffect())) return;
-            String effectName = NarrationUtils.narrateEffect(effectInstance);
+            if (Minecraft.getInstance().player.hasEffect(effect.getEffect())) return;
+            String effectName = NarrationUtils.narrateEffect(effect);
             MainClass.narrate(I18n.get("minecraft_access.effect_narration.gained") + ' ' + effectName, false);
         }
     }
 
     @Inject(method = "onEffectAdded", at = @At("TAIL"))
-    private void narrateEffectApplication2(MobEffectInstance effectInstance, Entity entity, CallbackInfo ci) {
+    private void narrateEffectApplication2(MobEffectInstance effect, Entity source, CallbackInfo ci) {
         if (Objects.equals(Minecraft.getInstance().player, this)) {
-            if (Minecraft.getInstance().player.hasEffect(effectInstance.getEffect())) return;
-            String effectName = NarrationUtils.narrateEffect(effectInstance);
+            if (Minecraft.getInstance().player.hasEffect(effect.getEffect())) return;
+            String effectName = NarrationUtils.narrateEffect(effect);
             MainClass.narrate(I18n.get("minecraft_access.effect_narration.gained") + ' ' + effectName, false);
         }
     }

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/MinecraftMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/MinecraftMixin.java
@@ -19,8 +19,8 @@ abstract class MinecraftMixin {
      * no screen opened and alt key with number key are pressed.
      * We need to suppress original hotbar slot selecting feature.
      */
-    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;isSpectator()Z"),
-            method = "handleKeybinds",
+    @Inject(method = "handleKeybinds",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;isSpectator()Z"),
             cancellable = true)
     private void suppressHotbarSlotSelecting(CallbackInfo ci) {
         if (hasAltDown()) {

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/MouseHandlerMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/MouseHandlerMixin.java
@@ -10,7 +10,7 @@ import org.mcaccess.minecraftaccess.MainClass;
 
 @Mixin(MouseHandler.class)
 abstract class MouseHandlerMixin {
-    @Inject(at = @At("HEAD"), method = "turnPlayer", cancellable = true)
+    @Inject(method = "turnPlayer", at = @At("HEAD"), cancellable = true)
     private void lockCamera(CallbackInfo ci) {
         if (MainClass.poiManager.lockingHandler.isPlayerLocked()) {
             ci.cancel();

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/NowPlayingToastMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/NowPlayingToastMixin.java
@@ -20,7 +20,7 @@ abstract class NowPlayingToastMixin {
         throw new AssertionError();
     }
 
-    @Inject(at = @At("TAIL"), method = "showToast")
+    @Inject(method = "showToast", at = @At("TAIL"))
     private void narrateSong(CallbackInfo ci) {
         String toastTextBuilder = I18n.get("minecraft_access.toast.shown")
                 + I18n.get("minecraft_access.other.words_connection")

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/RecipeBookPageMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/RecipeBookPageMixin.java
@@ -13,7 +13,7 @@ import org.mcaccess.minecraftaccess.features.inventory_controls.GroupGenerator;
 
 @Mixin(RecipeBookPage.class)
 abstract class RecipeBookPageMixin {
-    @Inject(at = @At("HEAD"), method = "updateCollections")
+    @Inject(method = "updateCollections", at = @At("HEAD"))
     private void saveResultsForRecipeGroupGenerating(List<RecipeCollection> recipeCollections, boolean resetPage, boolean isFiltering, CallbackInfo ci) {
         GroupGenerator.recipesOnTheScreen = recipeCollections;
     }

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/RecipeBookPageMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/RecipeBookPageMixin.java
@@ -14,7 +14,7 @@ import org.mcaccess.minecraftaccess.features.inventory_controls.GroupGenerator;
 @Mixin(RecipeBookPage.class)
 abstract class RecipeBookPageMixin {
     @Inject(at = @At("HEAD"), method = "updateCollections")
-    private void saveResultsForRecipeGroupGenerating(List<RecipeCollection> resultCollections, boolean resetCurrentPage, boolean filteringCraftable, CallbackInfo ci) {
-        GroupGenerator.recipesOnTheScreen = resultCollections;
+    private void saveResultsForRecipeGroupGenerating(List<RecipeCollection> recipeCollections, boolean resetPage, boolean isFiltering, CallbackInfo ci) {
+        GroupGenerator.recipesOnTheScreen = recipeCollections;
     }
 }

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/RecipeButtonMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/RecipeButtonMixin.java
@@ -33,7 +33,7 @@ abstract class RecipeButtonMixin {
     public abstract ItemStack getDisplayStack();
 
     @Inject(at = @At("HEAD"), method = "updateWidgetNarration", cancellable = true)
-    private void updateWidgetNarrationsMixin(CallbackInfo callbackInfo) {
+    private void updateWidgetNarrationsMixin(CallbackInfo ci) {
         ItemStack itemStack = getDisplayStack();
         String itemName = itemStack.getHoverName().getString();
 
@@ -52,7 +52,7 @@ abstract class RecipeButtonMixin {
         }
 
         shakeTheMouse();
-        callbackInfo.cancel();
+        ci.cancel();
     }
 
     /**

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/RecipeButtonMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/RecipeButtonMixin.java
@@ -17,17 +17,14 @@ import org.mcaccess.minecraftaccess.utils.system.MouseUtils;
 
 @Mixin(RecipeButton.class)
 abstract class RecipeButtonMixin {
-    @Shadow
-    private RecipeCollection collection;
-
-    @Unique
-    private boolean vibratingFlag = false;
-
-    @Unique
-    private String previousItemName = "";
-
     @Unique
     private final Interval interval = Interval.ms(5000);
+    @Shadow
+    private RecipeCollection collection;
+    @Unique
+    private boolean vibratingFlag = false;
+    @Unique
+    private String previousItemName = "";
 
     @Shadow
     public abstract ItemStack getDisplayStack();

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/RecipeButtonMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/RecipeButtonMixin.java
@@ -32,7 +32,7 @@ abstract class RecipeButtonMixin {
     @Shadow
     public abstract ItemStack getDisplayStack();
 
-    @Inject(at = @At("HEAD"), method = "updateWidgetNarration", cancellable = true)
+    @Inject(method = "updateWidgetNarration", at = @At("HEAD"), cancellable = true)
     private void updateWidgetNarrationsMixin(CallbackInfo ci) {
         ItemStack itemStack = getDisplayStack();
         String itemName = itemStack.getHoverName().getString();

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/SuggestionsListMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/SuggestionsListMixin.java
@@ -29,13 +29,15 @@ import org.mcaccess.minecraftaccess.MainClass;
 abstract class SuggestionsListMixin {
     @Shadow
     private int lastNarratedEntry;
+
     @Shadow
     private int current;
+
     @Shadow
     @Final
     private List<Suggestion> suggestionList;
 
-    @Inject(at = @At("HEAD"), method = "getNarrationMessage", cancellable = true)
+    @Inject(method = "getNarrationMessage", at = @At("HEAD"), cancellable = true)
     private void simplifySuggestionNarration(CallbackInfoReturnable<Component> cir) {
         // Don't know why they update this value here
         lastNarratedEntry = current;
@@ -60,13 +62,13 @@ abstract class SuggestionsListMixin {
         return textNarration;
     }
 
-    @Inject(at = @At("HEAD"), method = "useSuggestion")
+    @Inject(method = "useSuggestion", at = @At("HEAD"))
     private void narrateCompletion(CallbackInfo ci) {
         String selected = suggestionList.get(current).getText();
         MainClass.narrate(selected, true);
     }
 
-    @Inject(at = @At("RETURN"), method = "<init>")
+    @Inject(method = "<init>", at = @At("RETURN"))
     private void narrateFirstSuggestionWhenSuggestionsAreShown(CallbackInfo ci) {
         String first = getSuggestionTextNarration();
         MainClass.narrate(first, true);

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/TamableAnimalMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/TamableAnimalMixin.java
@@ -11,7 +11,7 @@ import org.mcaccess.minecraftaccess.MainClass;
 
 @Mixin(TamableAnimal.class)
 abstract class TamableAnimalMixin {
-    @Inject(at = @At("HEAD"), method = "spawnTamingParticles")
+    @Inject(method = "spawnTamingParticles", at = @At("HEAD"))
     private void narrateEmotion(boolean success, CallbackInfo ci) {
         String name = ((EntityAccessor) this).callGetName().getString();
         if (success) {

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/TamableAnimalMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/TamableAnimalMixin.java
@@ -12,9 +12,9 @@ import org.mcaccess.minecraftaccess.MainClass;
 @Mixin(TamableAnimal.class)
 abstract class TamableAnimalMixin {
     @Inject(at = @At("HEAD"), method = "spawnTamingParticles")
-    private void narrateEmotion(boolean positive, CallbackInfo ci) {
+    private void narrateEmotion(boolean success, CallbackInfo ci) {
         String name = ((EntityAccessor) this).callGetName().getString();
-        if (positive) {
+        if (success) {
             MainClass.narrate(I18n.get("minecraft_access.read_crosshair.like_your_behavior", name), true);
         } else {
             MainClass.narrate(I18n.get("minecraft_access.read_crosshair.dislike_your_behavior", name), true);

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/TextFieldHelperMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/TextFieldHelperMixin.java
@@ -101,8 +101,8 @@ abstract class TextFieldHelperMixin {
     }
 
     @Inject(at = @At("HEAD"), method = "removeCharsFromCursor")
-    private void narrateErasedText(int offset, CallbackInfo ci) {
-        int cursorPos = Util.offsetByCodepoints(getMessageFn.get(), this.cursorPos, offset);
+    private void narrateErasedText(int count, CallbackInfo ci) {
+        int cursorPos = Util.offsetByCodepoints(getMessageFn.get(), this.cursorPos, count);
         // select all text (ctrl+a) will not change the cursor position,
         // if we delete all text then, the erasedText will be a wrong value (one char ahead of cursor)
         // don't narrate under this condition

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/TextFieldHelperMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/TextFieldHelperMixin.java
@@ -30,20 +30,22 @@ abstract class TextFieldHelperMixin {
     @Final
     @Shadow
     private Supplier<String> getMessageFn;
+
     @Shadow
     private int cursorPos;
+
     @Shadow
     private int selectionPos;
 
     @Shadow
     protected abstract String getSelected(String string);
 
-    @Inject(at = @At("TAIL"), method = "setCursorToEnd()V")
+    @Inject(method = "setCursorToEnd()V", at = @At("TAIL"))
     private void narrateTextOfSwitchedLine(CallbackInfo ci) {
         MainClass.narrate(getMessageFn.get(), true);
     }
 
-    @Inject(at = @At("HEAD"), method = "keyPressed")
+    @Inject(method = "keyPressed", at = @At("HEAD"))
     private void narrateCursorHoverOverText(KeyEvent event, CallbackInfoReturnable<Boolean> cir) {
         // is selecting, let the selecting text narrating method do the job instead
         if (Minecraft.getInstance().hasShiftDown()) {
@@ -94,13 +96,13 @@ abstract class TextFieldHelperMixin {
         return Util.offsetByCodepoints(getMessageFn.get(), cursorPos, offset);
     }
 
-    @Inject(at = @At("RETURN"), method = "keyPressed")
+    @Inject(method = "keyPressed", at = @At("RETURN"))
     private void narrateSelectedText(CallbackInfoReturnable<Boolean> cir) {
         String selectedText = getSelected(getMessageFn.get());
         MainClass.narrate(selectedText, true);
     }
 
-    @Inject(at = @At("HEAD"), method = "removeCharsFromCursor")
+    @Inject(method = "removeCharsFromCursor", at = @At("HEAD"))
     private void narrateErasedText(int count, CallbackInfo ci) {
         int cursorPos = Util.offsetByCodepoints(getMessageFn.get(), this.cursorPos, count);
         // select all text (ctrl+a) will not change the cursor position,

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/ToastManagerMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/ToastManagerMixin.java
@@ -19,7 +19,7 @@ import org.mcaccess.minecraftaccess.utils.NarrationUtils;
 
 @Mixin(ToastManager.class)
 abstract class ToastManagerMixin {
-    @Inject(at = @At("TAIL"), method = "addToast")
+    @Inject(method = "addToast", at = @At("TAIL"))
     private void narrateToast(Toast toast, CallbackInfo ci) {
         StringBuilder toastTextBuilder = new StringBuilder();
         toastTextBuilder.append(I18n.get("minecraft_access.toast.shown"))

--- a/src/main/java/org/mcaccess/minecraftaccess/mixin/WinScreenMixin.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/mixin/WinScreenMixin.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(WinScreen.class)
 abstract class WinScreenMixin {
-    @ModifyReturnValue(at = @At("RETURN"), method = "getNarrationMessage")
+    @ModifyReturnValue(method = "getNarrationMessage", at = @At("RETURN"))
     private Component addCreditsTip(Component original) {
         return Component.translatable("minecraft_access.credits_screen.started_tip")
                 .append(Component.translatable("minecraft_access.other.words_connection"))


### PR DESCRIPTION
This PR uses the unobfuscated parameter names from the game code for mixin method signatures as well as making ``method =`` consistently the first item set in the annotations.