### PR TITLE
Fixed Javadoc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Javadoc
         run: |
           ./gradlew :javadoc
+          mkdir -p ./docs/static/api/client/
+          cp -r ./build/docs/javadoc ./docs/static/api/client/
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
         id: pages
       - name: Build

--- a/docs/static/api/client/javadoc
+++ b/docs/static/api/client/javadoc
@@ -1,1 +1,0 @@
-../../../../build/docs/javadoc/


### PR DESCRIPTION
Hugo [v0.163.1](https://github.com/gohugoio/hugo/releases/tag/v0.163.1) no longer supports symlinks.