### PR TITLE
Narrate carried items in inventory screens

### DIFF
--- a/src/main/java/org/mcaccess/minecraftaccess/addon/worldnarrators/MinecraftAccess.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/addon/worldnarrators/MinecraftAccess.java
@@ -202,7 +202,7 @@ public class MinecraftAccess implements WorldNarrator {
                     I18n.get("minecraft_access.read_crosshair.zombie_villager_is_curing", text);
             case Display.ItemDisplay itemDisplay when itemDisplay.itemRenderState() != null -> {
                 @SuppressWarnings("DataFlowIssue")
-                String itemName = itemDisplay.itemRenderState().itemStack().getItemName().getString();
+                String itemName = NarrateHeldItem.getItemName(itemDisplay.itemRenderState().itemStack(), true);
                 yield I18n.get("minecraft_access.point_of_interest.locking.display_item", itemName);
             }
             case Display.TextDisplay textDisplay when textDisplay.textRenderState() != null -> //noinspection DataFlowIssue
@@ -216,7 +216,13 @@ public class MinecraftAccess implements WorldNarrator {
                     Map.of("entity", text, "equipments", NarrateHeldItem.getItemName(frame.getItem(), true)));
             default -> {
                 if (isDroppedItem) {
-                    yield I18n.get("minecraft_access.point_of_interest.locking.dropped_item", text);
+                    if (entity instanceof ItemEntity item) {
+                        yield I18n.get("minecraft_access.point_of_interest.locking.dropped_item",
+                                NarrateHeldItem.getItemName(item.getItem(), true));
+                    } else if (entity instanceof AbstractArrow arrow) {
+                        yield I18n.get("minecraft_access.point_of_interest.locking.dropped_item",
+                                NarrateHeldItem.getItemName(arrow.getPickupItemStackOrigin(), true));
+                    }
                 }
                 yield text;
             }

--- a/src/main/java/org/mcaccess/minecraftaccess/addon/worldnarrators/MinecraftAccess.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/addon/worldnarrators/MinecraftAccess.java
@@ -281,8 +281,8 @@ public class MinecraftAccess implements WorldNarrator {
      * @param blockPos block position (in the client world)
      * @param side     if side is provided, then the invoker is ReadCrosshair
      * @return (narration, currentQuery):
-     * "narration" is the actual one to be narrated through Narrator,
-     * "currentQuery" is kind of shortened "narration" that is used for checking if target is changed compared to previous.
+     *      "narration" is the actual one to be narrated through Narrator,
+     *      "currentQuery" is kind of shortened "narration" that is used for checking if target is changed compared to previous.
      */
     private static String narrateBlock(BlockPos blockPos, String side) {
         Minecraft client = Minecraft.getInstance();
@@ -525,8 +525,8 @@ public class MinecraftAccess implements WorldNarrator {
     /**
      * @param pos fluid position (in the client world)
      * @return (narration, currentQuery):
-     * "narration" is the actual one to be narrated through Narrator,
-     * "currentQuery" is kind of shortened "narration" that is used for checking if target is changed compared to previous.
+     *      "narration" is the actual one to be narrated through Narrator,
+     *      "currentQuery" is kind of shortened "narration" that is used for checking if target is changed compared to previous.
      */
     private static String narrateFluidBlock(BlockPos pos) {
         assert Minecraft.getInstance().level != null;

--- a/src/main/java/org/mcaccess/minecraftaccess/addon/worldnarrators/MinecraftAccess.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/addon/worldnarrators/MinecraftAccess.java
@@ -79,6 +79,7 @@ import org.jetbrains.annotations.Nullable;
 
 import org.mcaccess.minecraftaccess.Config;
 import org.mcaccess.minecraftaccess.api.WorldNarrator;
+import org.mcaccess.minecraftaccess.features.NarrateHeldItem;
 import org.mcaccess.minecraftaccess.mixin.BaseSpawnerAccessor;
 import org.mcaccess.minecraftaccess.mixin.WolfAccessor;
 import org.mcaccess.minecraftaccess.utils.NarrationUtils;
@@ -211,14 +212,8 @@ public class MinecraftAccess implements WorldNarrator {
                 Block ghostBlock = blockDisplay.blockRenderState().blockState().getBlock();
                 yield I18n.get("minecraft_access.point_of_interest.locking.display_block", ghostBlock.getName().getString());
             }
-            case ItemFrame frame -> {
-                ItemStack item = frame.getItem();
-                if (!item.isEmpty()) {
-                    String itemName = item.getItemName().getString();
-                    yield I18n.get("minecraft_access.other.entity_with_equipments", Map.of("entity", text, "equipments", itemName));
-                }
-                yield text;
-            }
+            case ItemFrame frame -> I18n.get("minecraft_access.other.entity_with_equipments",
+                    Map.of("entity", text, "equipments", NarrateHeldItem.getItemName(frame.getItem(), true)));
             default -> {
                 if (isDroppedItem) {
                     yield I18n.get("minecraft_access.point_of_interest.locking.dropped_item", text);
@@ -280,8 +275,8 @@ public class MinecraftAccess implements WorldNarrator {
      * @param blockPos block position (in the client world)
      * @param side     if side is provided, then the invoker is ReadCrosshair
      * @return (narration, currentQuery):
-     *      "narration" is the actual one to be narrated through Narrator,
-     *      "currentQuery" is kind of shortened "narration" that is used for checking if target is changed compared to previous.
+     * "narration" is the actual one to be narrated through Narrator,
+     * "currentQuery" is kind of shortened "narration" that is used for checking if target is changed compared to previous.
      */
     private static String narrateBlock(BlockPos blockPos, String side) {
         Minecraft client = Minecraft.getInstance();
@@ -524,8 +519,8 @@ public class MinecraftAccess implements WorldNarrator {
     /**
      * @param pos fluid position (in the client world)
      * @return (narration, currentQuery):
-     *      "narration" is the actual one to be narrated through Narrator,
-     *      "currentQuery" is kind of shortened "narration" that is used for checking if target is changed compared to previous.
+     * "narration" is the actual one to be narrated through Narrator,
+     * "currentQuery" is kind of shortened "narration" that is used for checking if target is changed compared to previous.
      */
     private static String narrateFluidBlock(BlockPos pos) {
         assert Minecraft.getInstance().level != null;

--- a/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
@@ -89,7 +89,7 @@ public class NarrateHeldItem implements BalmClientModule {
         previousSelectedSlot.value = selectedSlot;
     }
 
-    private String getItemName(ItemStack itemStack, boolean addCount) {
+    public static String getItemName(ItemStack itemStack, boolean addCount) {
         if (itemStack.isEmpty()) {
             return I18n.get("minecraft_access.inventory_controls.empty_slot", "");
         }

--- a/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
@@ -44,16 +44,9 @@ public class NarrateHeldItem implements BalmClientModule {
                 .withDefault(InputBinding.key(InputConstants.KEY_GRAVE))
                 .overrideCategory(KeyMappingCategories.OTHER)
                 .handleScreenInput(event -> {
-                    if (event.screen() instanceof AbstractContainerScreen) {
-                        ItemStack heldItem = Minecraft.getInstance().player.containerMenu.getCarried();
-                        String heldItemName = getItemName(heldItem);
-                        int heldItemCount = heldItem.getCount();
-                        heldItemName = (heldItemCount != 1 && !heldItem.isEmpty()) ? heldItemCount + " " + heldItemName : heldItemName;
-
-                        MainClass.narrate(heldItemName, false);
-                        return true;
-                    }
-                    return false;
+                    if (!(event.screen() instanceof AbstractContainerScreen)) return false;
+                    MainClass.narrate(getItemName(Minecraft.getInstance().player.containerMenu.getCarried(), true), false);
+                    return true;
                 })
                 .handleWorldInput(_ -> {
                     narrateHand(false);
@@ -75,20 +68,20 @@ public class NarrateHeldItem implements BalmClientModule {
         if (player.isSpectator()) return;
 
         ItemStack currentItemStack = player.getMainHandItem();
+        String baseItemName = getItemName(currentItemStack, false);
         int selectedSlot = player.getInventory().getSelectedSlot();
-        String baseItemName = getItemName(currentItemStack);
         int itemCount = currentItemStack.getCount();
-
-        String itemNameWithCount = (currentItemStack.getCount() != 1 && !currentItemStack.isEmpty()) ? itemCount + " " + baseItemName : baseItemName;
 
         boolean nameChanged = !Objects.equals(baseItemName, previousItemName.value);
         boolean countChanged = !Objects.equals(itemCount, previousItemCount.value);
         boolean slotChanged = !Objects.equals(selectedSlot, previousSelectedSlot.value);
 
         if (nameChanged || slotChanged) {
-            MainClass.narrate(I18n.get("minecraft_access.other.selected", itemNameWithCount), true);
+            MainClass.narrate(I18n.get("minecraft_access.other.selected", getItemName(currentItemStack, true)), true);
         } else if (countChanged && Config.getInstance().features.narrateHeldItemsCountWhenChanged) {
             MainClass.narrate(String.valueOf(itemCount), true);
+        } else {
+            return;
         }
 
         previousItemName.value = baseItemName;
@@ -96,7 +89,7 @@ public class NarrateHeldItem implements BalmClientModule {
         previousSelectedSlot.value = selectedSlot;
     }
 
-    private String getItemName(ItemStack itemStack) {
+    private String getItemName(ItemStack itemStack, boolean addCount) {
         if (itemStack.isEmpty()) {
             return I18n.get("minecraft_access.inventory_controls.empty_slot", "");
         }
@@ -108,7 +101,8 @@ public class NarrateHeldItem implements BalmClientModule {
                 .flatMap(jukeboxPlayable -> jukeboxPlayable.song().unwrapKey())
                 .ifPresent(discNumber -> itemName.append(' ').append(I18n.get("jukebox_song.minecraft." + discNumber.identifier().getPath())));
 
-        return itemName.toString();
+        int heldItemCount = itemStack.getCount();
+        return (addCount && heldItemCount != 1 && !itemStack.isEmpty()) ? heldItemCount + " " + itemName.toString() : itemName.toString();
     }
 
     private void narrateHand(boolean hasAltDown) {
@@ -116,21 +110,17 @@ public class NarrateHeldItem implements BalmClientModule {
 
         LocalPlayer player = Minecraft.getInstance().player;
         String hand;
-        ItemStack heldItem;
+        String heldItemName;
 
         if (!hasAltDown) {
             hand = I18n.get("options.mainHand");
             assert player != null;
-            heldItem = player.getMainHandItem();
+            heldItemName = getItemName(player.getMainHandItem(), true);
         } else {
             hand = I18n.get("minecraft_access.other.offhand");
             assert player != null;
-            heldItem = player.getOffhandItem();
+            heldItemName = getItemName(player.getOffhandItem(), true);
         }
-
-        String heldItemName = getItemName(heldItem);
-        int heldItemCount = heldItem.getCount();
-        heldItemName = (heldItemCount != 1 && !heldItem.isEmpty()) ? heldItemCount + " " + heldItemName : heldItemName;
 
         MainClass.narrate("%s: %s".formatted(hand, heldItemName), false);
     }

--- a/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
@@ -50,7 +50,8 @@ public class NarrateHeldItem implements BalmClientModule {
                 .overrideCategory(KeyMappingCategories.OTHER)
                 .handleScreenInput(event -> {
                     if (!(event.screen() instanceof AbstractContainerScreen)) return false;
-                    MainClass.narrate(getItemName(Minecraft.getInstance().player.containerMenu.getCarried(), true), false);
+                    MainClass.narrate(I18n.get("minecraft_access.inventory_controls.dragging",
+                            getItemName(Minecraft.getInstance().player.containerMenu.getCarried(), true)), false);
                     return true;
                 })
                 .handleWorldInput(_ -> {

--- a/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
@@ -11,6 +11,7 @@ import net.blay09.mods.kuma.api.KeyModifier;
 import net.blay09.mods.kuma.api.KeyModifiers;
 import net.blay09.mods.kuma.api.Kuma;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.component.DataComponents;
@@ -42,6 +43,18 @@ public class NarrateHeldItem implements BalmClientModule {
         Kuma.createKeyMapping(Identifier.fromNamespaceAndPath(MainClass.MOD_ID, "other.narrate_held_item/mainhand"))
                 .withDefault(InputBinding.key(InputConstants.KEY_GRAVE))
                 .overrideCategory(KeyMappingCategories.OTHER)
+                .handleScreenInput(event -> {
+                    if (event.screen() instanceof AbstractContainerScreen) {
+                        ItemStack heldItem = Minecraft.getInstance().player.containerMenu.getCarried();
+                        String heldItemName = getItemName(heldItem);
+                        int heldItemCount = heldItem.getCount();
+                        heldItemName = (heldItemCount != 1 && !heldItem.isEmpty()) ? heldItemCount + " " + heldItemName : heldItemName;
+
+                        MainClass.narrate(heldItemName, false);
+                        return true;
+                    }
+                    return false;
+                })
                 .handleWorldInput(_ -> {
                     narrateHand(false);
                     return true;

--- a/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
@@ -17,13 +17,13 @@ import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.BundleItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.LightBlock;
 import net.minecraft.world.level.block.TestBlock;
 import net.minecraft.world.level.block.state.properties.TestBlockMode;
+import org.apache.commons.lang3.math.Fraction;
 import org.jetbrains.annotations.NotNull;
 
 import org.mcaccess.minecraftaccess.Config;
@@ -79,15 +79,13 @@ public class NarrateHeldItem implements BalmClientModule {
         int itemCount = currentItemStack.getCount();
 
         boolean nameChanged = !Objects.equals(baseItemName, previousItemName.value);
-        boolean countChanged = Config.getInstance().features.narrateHeldItemsCountWhenChanged && !Objects.equals(itemCount, previousItemCount.value);
+        boolean countChanged = !Objects.equals(itemCount, previousItemCount.value);
         boolean slotChanged = !Objects.equals(selectedSlot, previousSelectedSlot.value);
 
         if (nameChanged || slotChanged) {
             MainClass.narrate(I18n.get("minecraft_access.other.selected", getItemName(currentItemStack, true)), true);
-        } else if (countChanged) {
+        } else if (Config.getInstance().features.narrateHeldItemsCountWhenChanged && countChanged) {
             MainClass.narrate(String.valueOf(itemCount), true);
-        } else {
-            return;
         }
 
         previousItemName.value = baseItemName;
@@ -119,8 +117,10 @@ public class NarrateHeldItem implements BalmClientModule {
         }
 
         if (itemStack.has(DataComponents.BUNDLE_CONTENTS)) {
-            int weight = Math.round(BundleItem.getFullnessDisplay(itemStack) * 64);
-            itemName.append(' ').append(weight).append("/64");
+            itemStack.get(DataComponents.BUNDLE_CONTENTS).weight().result().ifPresent(fraction ->
+                    itemName.append(' ')
+                            .append(fraction.multiplyBy(Fraction.getFraction(64, 1)).getNumerator())
+                            .append("/64"));
         }
 
         int heldItemCount = itemStack.getCount();
@@ -128,11 +128,11 @@ public class NarrateHeldItem implements BalmClientModule {
     }
 
     private void narrateHand(boolean hasAltDown) {
-        if (Minecraft.getInstance().player.isSpectator()) return;
-
         LocalPlayer player = Minecraft.getInstance().player;
-        String hand = I18n.get(hasAltDown ? "minecraft_access.other.offhand" : "options.mainHand");
         assert player != null;
+        if (player.isSpectator()) return;
+
+        String hand = I18n.get(hasAltDown ? "minecraft_access.other.offhand" : "options.mainHand");
         String heldItemName = getItemName(hasAltDown ? player.getOffhandItem() : player.getMainHandItem(), true);
 
         MainClass.narrate("%s: %s".formatted(hand, heldItemName), false);

--- a/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
@@ -18,8 +18,11 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.LightBlock;
+import net.minecraft.world.level.block.TestBlock;
+import net.minecraft.world.level.block.state.properties.TestBlockMode;
 import org.jetbrains.annotations.NotNull;
 
 import org.mcaccess.minecraftaccess.Config;
@@ -105,6 +108,13 @@ public class NarrateHeldItem implements BalmClientModule {
         Optional.ofNullable(itemStack.get(DataComponents.BLOCK_STATE))
                 .map(blockState -> blockState.get(LightBlock.LEVEL))
                 .ifPresent(level -> itemName.append(' ').append(level));
+
+        if (itemStack.is(Items.TEST_BLOCK)) {
+            TestBlockMode mode = Optional.ofNullable(itemStack.get(DataComponents.BLOCK_STATE))
+                    .map(blockState -> blockState.get(TestBlock.MODE))
+                    .orElse(TestBlockMode.START);
+            itemName.append(' ').append(mode.getDisplayName().getString());
+        }
 
         int heldItemCount = itemStack.getCount();
         return (addCount && heldItemCount != 1 && !itemStack.isEmpty()) ? heldItemCount + " " + itemName.toString() : itemName.toString();

--- a/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
@@ -17,6 +17,7 @@ import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BundleItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
@@ -114,6 +115,11 @@ public class NarrateHeldItem implements BalmClientModule {
                     .map(blockState -> blockState.get(TestBlock.MODE))
                     .orElse(TestBlockMode.START);
             itemName.append(' ').append(mode.getDisplayName().getString());
+        }
+
+        if (itemStack.has(DataComponents.BUNDLE_CONTENTS)) {
+            int weight = Math.round(BundleItem.getFullnessDisplay(itemStack) * 64);
+            itemName.append(' ').append(weight).append("/64");
         }
 
         int heldItemCount = itemStack.getCount();

--- a/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
@@ -19,6 +19,7 @@ import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.LightBlock;
 import org.jetbrains.annotations.NotNull;
 
 import org.mcaccess.minecraftaccess.Config;
@@ -100,6 +101,10 @@ public class NarrateHeldItem implements BalmClientModule {
         Optional.ofNullable(itemStack.get(DataComponents.JUKEBOX_PLAYABLE))
                 .flatMap(jukeboxPlayable -> jukeboxPlayable.song().unwrapKey())
                 .ifPresent(discNumber -> itemName.append(' ').append(I18n.get("jukebox_song.minecraft." + discNumber.identifier().getPath())));
+
+        Optional.ofNullable(itemStack.get(DataComponents.BLOCK_STATE))
+                .map(blockState -> blockState.get(LightBlock.LEVEL))
+                .ifPresent(level -> itemName.append(' ').append(level));
 
         int heldItemCount = itemStack.getCount();
         return (addCount && heldItemCount != 1 && !itemStack.isEmpty()) ? heldItemCount + " " + itemName.toString() : itemName.toString();

--- a/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
@@ -74,17 +74,17 @@ public class NarrateHeldItem implements BalmClientModule {
         if (player.isSpectator()) return;
 
         ItemStack currentItemStack = player.getMainHandItem();
-        String baseItemName = getItemName(currentItemStack, false);
         int selectedSlot = player.getInventory().getSelectedSlot();
+        String baseItemName = getItemName(currentItemStack, false);
         int itemCount = currentItemStack.getCount();
 
         boolean nameChanged = !Objects.equals(baseItemName, previousItemName.value);
-        boolean countChanged = !Objects.equals(itemCount, previousItemCount.value);
+        boolean countChanged = Config.getInstance().features.narrateHeldItemsCountWhenChanged && !Objects.equals(itemCount, previousItemCount.value);
         boolean slotChanged = !Objects.equals(selectedSlot, previousSelectedSlot.value);
 
         if (nameChanged || slotChanged) {
             MainClass.narrate(I18n.get("minecraft_access.other.selected", getItemName(currentItemStack, true)), true);
-        } else if (countChanged && Config.getInstance().features.narrateHeldItemsCountWhenChanged) {
+        } else if (countChanged) {
             MainClass.narrate(String.valueOf(itemCount), true);
         } else {
             return;
@@ -124,7 +124,7 @@ public class NarrateHeldItem implements BalmClientModule {
         }
 
         int heldItemCount = itemStack.getCount();
-        return (addCount && heldItemCount != 1 && !itemStack.isEmpty()) ? heldItemCount + " " + itemName.toString() : itemName.toString();
+        return (addCount && heldItemCount != 1) ? heldItemCount + " " + itemName.toString() : itemName.toString();
     }
 
     private void narrateHand(boolean hasAltDown) {

--- a/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/features/NarrateHeldItem.java
@@ -124,25 +124,16 @@ public class NarrateHeldItem implements BalmClientModule {
         }
 
         int heldItemCount = itemStack.getCount();
-        return (addCount && heldItemCount != 1) ? heldItemCount + " " + itemName.toString() : itemName.toString();
+        return (addCount && heldItemCount != 1) ? heldItemCount + " " + itemName : itemName.toString();
     }
 
     private void narrateHand(boolean hasAltDown) {
         if (Minecraft.getInstance().player.isSpectator()) return;
 
         LocalPlayer player = Minecraft.getInstance().player;
-        String hand;
-        String heldItemName;
-
-        if (!hasAltDown) {
-            hand = I18n.get("options.mainHand");
-            assert player != null;
-            heldItemName = getItemName(player.getMainHandItem(), true);
-        } else {
-            hand = I18n.get("minecraft_access.other.offhand");
-            assert player != null;
-            heldItemName = getItemName(player.getOffhandItem(), true);
-        }
+        String hand = I18n.get(hasAltDown ? "minecraft_access.other.offhand" : "options.mainHand");
+        assert player != null;
+        String heldItemName = getItemName(hasAltDown ? player.getOffhandItem() : player.getMainHandItem(), true);
 
         MainClass.narrate("%s: %s".formatted(hand, heldItemName), false);
     }

--- a/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/InventoryControls.java
+++ b/src/main/java/org/mcaccess/minecraftaccess/features/inventory_controls/InventoryControls.java
@@ -2,7 +2,6 @@ package org.mcaccess.minecraftaccess.features.inventory_controls;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +26,6 @@ import net.minecraft.client.gui.screens.recipebook.SearchRecipeBookCategory;
 import net.minecraft.client.input.MouseButtonInfo;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.sounds.SoundEvents;
@@ -48,6 +46,7 @@ import org.jetbrains.annotations.Nullable;
 
 import org.mcaccess.minecraftaccess.Config;
 import org.mcaccess.minecraftaccess.MainClass;
+import org.mcaccess.minecraftaccess.features.NarrateHeldItem;
 import org.mcaccess.minecraftaccess.mixin.AbstractContainerScreenAccessor;
 import org.mcaccess.minecraftaccess.mixin.AbstractRecipeBookScreenAccessor;
 import org.mcaccess.minecraftaccess.mixin.AnvilScreenAccessor;
@@ -580,23 +579,44 @@ public class InventoryControls implements BalmClientModule {
         }
 
         ItemStack itemStack = slot.getItem();
-        // <slot row col prefix> <count>
-        String info = "%s %s".formatted(currentGroup.getSlotPrefix(slot),
-                (itemStack.getCount() != 1 && !itemStack.isEmpty()) ? String.valueOf(itemStack.getCount()) : "");
-
-        // <name> <description>
-        StringBuilder toolTipString = new StringBuilder();
-        List<Component> toolTipList = itemStack.getTooltipLines(TooltipContext.EMPTY, Minecraft.getInstance().player, TooltipFlag.NORMAL);
-        for (Component line : toolTipList) {
-            toolTipString.append(line.getString()).append(' ');
+        StringBuilder narration = new StringBuilder();
+        String prefix = currentGroup.getSlotPrefix(slot);
+        if (!prefix.isEmpty()) {
+            narration.append(prefix).append(' ');
         }
 
-        Optional.ofNullable(itemStack.get(DataComponents.JUKEBOX_PLAYABLE))
-                .flatMap(jukeboxPlayable -> jukeboxPlayable.song().unwrapKey())
-                .ifPresent(discNumber -> toolTipString.append(' ').append(I18n.get("jukebox_song.minecraft." + discNumber.identifier().getPath())));
+        int count = itemStack.getCount();
+        if (count != 1 && !itemStack.isEmpty()) {
+            narration.append(count).append(' ');
+        }
 
-        // <slot row col prefix> <count> <name> <description>
-        return "%s %s".formatted(info, toolTipString.toString());
+        String baseItemName = NarrateHeldItem.getItemName(itemStack, false);
+
+        List<Component> toolTipList = itemStack.getTooltipLines(TooltipContext.EMPTY, Minecraft.getInstance().player, TooltipFlag.NORMAL);
+        StringBuilder toolTipBuilder = new StringBuilder();
+        for (Component line : toolTipList) {
+            String text = line.getString();
+            if (!text.isEmpty()) {
+                toolTipBuilder.append(text).append(' ');
+            }
+        }
+        String toolTipText = toolTipBuilder.toString().trim();
+
+        if (toolTipText.contains(baseItemName)) {
+            narration.append(toolTipText);
+        } else if (toolTipText.isEmpty()) {
+            narration.append(baseItemName);
+        } else {
+            narration.append(baseItemName);
+            for (Component line : toolTipList) {
+                String text = line.getString();
+                if (!baseItemName.contains(text)) {
+                    narration.append(' ').append(text);
+                }
+            }
+        }
+
+        return narration.toString().trim();
     }
 
     /**

--- a/src/main/resources/assets/minecraft_access/lang/en_us.json
+++ b/src/main/resources/assets/minecraft_access/lang/en_us.json
@@ -143,6 +143,7 @@
     "minecraft_access.inventory_controls.Unknown": "Unknown",
     "minecraft_access.inventory_controls.direction_left": "Left",
     "minecraft_access.inventory_controls.direction_right": "Right",
+    "minecraft_access.inventory_controls.dragging": "Dragging %s",
     "minecraft_access.inventory_controls.empty_slot": "%s Empty Slot",
     "minecraft_access.inventory_controls.fuel_status": "Fuel: %d%%, output processing: %d%%",
     "minecraft_access.inventory_controls.group_selected": "%s %s Group selected",


### PR DESCRIPTION
# Changelog

## New Features
- Using the narrate held item key in your inventory now speaks items that are carried by your cursor
- Light block light level is now narrated in the inventory.
- Test block mode is now narrated in the inventory.
- Bundle fullness progress is now narrated in the inventory.
- item narration is now shared across the entire mod for consistency